### PR TITLE
fix: improve order page QOL

### DIFF
--- a/src/components/ssh-keys.tsx
+++ b/src/components/ssh-keys.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { UserSshKey } from "../api";
 import useLogin from "../hooks/login";
 import { AsyncButton } from "./button";
@@ -16,18 +16,37 @@ export default function SSHKeySelector({
   const [newKeyName, setNewKeyName] = useState("");
   const [showAddKey, setShowAddKey] = useState(false);
   const [sshKeys, setSshKeys] = useState<Array<UserSshKey>>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const loadKeys = useCallback(async () => {
+    if (!login?.api) return;
+    setIsLoading(true);
+    try {
+      const keys = await login.api.listSshKeys();
+      setSshKeys(keys);
+      // Only auto-select if no key is currently selected
+      if (selectedKey === -1 && keys.length > 0) {
+        setSelectedKey(keys[0].id);
+      } else if (keys.length === 0) {
+        setShowAddKey(true);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [login?.api, selectedKey, setSelectedKey]);
 
   async function addNewKey() {
     if (!login?.api) return;
     setNewKeyError("");
 
     try {
-      const nk = await login?.api.addSshKey(newKeyName, newKey);
+      const nk = await login.api.addSshKey(newKeyName, newKey);
       setNewKey("");
       setNewKeyName("");
       setSelectedKey(nk.id);
       setShowAddKey(false);
-      login?.api.listSshKeys().then((a) => setSshKeys(a));
+      // Reload the keys list to include the new key
+      await loadKeys();
     } catch (e) {
       if (e instanceof Error) {
         setNewKeyError(e.message);
@@ -36,20 +55,13 @@ export default function SSHKeySelector({
   }
 
   useEffect(() => {
-    if (!login?.api) return;
-    login?.api.listSshKeys().then((a) => {
-      setSshKeys(a);
-      if (a.length > 0) {
-        setSelectedKey(a[0].id);
-      } else {
-        setShowAddKey(true);
-      }
-    });
-  }, []);
+    loadKeys();
+  }, [loadKeys]);
 
   return (
     <div className="flex flex-col gap-2">
-      {sshKeys.length > 0 && (
+      {isLoading && <div className="text-cyber-muted">Loading SSH keys...</div>}
+      {!isLoading && sshKeys.length > 0 && (
         <>
           <b className="text-cyber-primary">Select SSH Key:</b>
           <select
@@ -58,17 +70,19 @@ export default function SSHKeySelector({
             onChange={(e) => setSelectedKey(Number(e.target.value))}
           >
             {sshKeys.map((a) => (
-              <option value={a.id}>{a.name}</option>
+              <option key={a.id} value={a.id}>
+                {a.name}
+              </option>
             ))}
           </select>
         </>
       )}
-      {!showAddKey && sshKeys.length > 0 && (
+      {!isLoading && !showAddKey && sshKeys.length > 0 && (
         <AsyncButton onClick={() => setShowAddKey(true)}>
           Add new SSH key
         </AsyncButton>
       )}
-      {(showAddKey || sshKeys.length === 0) && (
+      {!isLoading && (showAddKey || sshKeys.length === 0) && (
         <>
           <b className="text-cyber-primary">Add SSH Key:</b>
           <textarea

--- a/src/pages/order/vm.tsx
+++ b/src/pages/order/vm.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom";
-import { VmOsImage, VmTemplate } from "../../api";
-import { useEffect, useState } from "react";
+import { LNVpsApi, VmOsImage, VmTemplate } from "../../api";
+import { useEffect, useMemo, useState } from "react";
 import CostLabel from "../../components/cost";
 import useLogin from "../../hooks/login";
 import { AsyncButton } from "../../components/button";
@@ -9,6 +9,7 @@ import VpsResources from "../../components/vps-resources";
 import OsImageName from "../../components/os-image-name";
 import SSHKeySelector from "../../components/ssh-keys";
 import { clearRefCode, getRefCode } from "../../ref";
+import { ApiUrl } from "../../const";
 
 export default function OrderVmPage({ template }: { template: VmTemplate }) {
   const login = useLogin();
@@ -18,10 +19,22 @@ export default function OrderVmPage({ template }: { template: VmTemplate }) {
   const [images, setImages] = useState<Array<VmOsImage>>([]);
   const [orderError, setOrderError] = useState("");
 
+  // Fetch images without auth (public endpoint) to reduce signer burden
   useEffect(() => {
-    if (!login?.api) return;
-    login.api.listOsImages().then((a) => setImages(a));
-  }, [login]);
+    const api = new LNVpsApi(ApiUrl, undefined);
+    api.listOsImages().then((a) => {
+      setImages(a);
+      // Auto-select the first (most recent) image
+      if (a.length > 0) {
+        const sorted = [...a].sort(
+          (x, y) =>
+            new Date(y.release_date).getTime() -
+            new Date(x.release_date).getTime(),
+        );
+        setUseImage(sorted[0].id);
+      }
+    });
+  }, []);
 
   async function createOrder() {
     if (!login?.api || !template) return;
@@ -55,9 +68,14 @@ export default function OrderVmPage({ template }: { template: VmTemplate }) {
     }
   }
 
-  const sortedImages = images.sort(
-    (a, b) =>
-      new Date(b.release_date).getTime() - new Date(a.release_date).getTime(),
+  const sortedImages = useMemo(
+    () =>
+      [...images].sort(
+        (a, b) =>
+          new Date(b.release_date).getTime() -
+          new Date(a.release_date).getTime(),
+      ),
+    [images],
   );
 
   if (!template) {


### PR DESCRIPTION
## Summary

Improves the order page quality of life as requested in #2:

- **Auto-select OS image**: Automatically selects the most recent OS image when images load
- **Reduce signer burden**: Fetches OS images from public endpoint without requiring Nostr authentication
- **Fix SSH key state issues**: 
  - Fixed missing useEffect dependencies that could cause stale state
  - Added useCallback for loadKeys to prevent infinite re-render loops
  - Added loading state to prevent interaction during key fetch
  - Fixed race condition when adding new SSH keys

Closes #2