### PR TITLE
Save Revolut card for off-session automatic renewals

### DIFF
--- a/src/components/revolut.tsx
+++ b/src/components/revolut.tsx
@@ -16,6 +16,8 @@ interface RevolutProps {
   onPaid: () => void;
   onCancel?: () => void;
   mode?: Mode;
+  /** Save the card for merchant-initiated (off-session) automatic renewals */
+  saveCard?: boolean;
 }
 
 export function RevolutPayWidget({
@@ -24,6 +26,7 @@ export function RevolutPayWidget({
   onPaid,
   onCancel,
   mode,
+  saveCard,
 }: RevolutProps) {
   const login = useLogin();
   const { formatMessage } = useIntl();
@@ -163,6 +166,10 @@ export function RevolutPayWidget({
         streetLine1: streetLine1 || undefined,
         streetLine2: streetLine2 || undefined,
       },
+      // Save the payment method for merchant-initiated (off-session) automatic
+      // renewals. The backend then captures the saved customer/payment-method
+      // ids on webhook completion.
+      ...(saveCard ? { savePaymentMethodFor: "merchant" as const } : {}),
     });
   }
 

--- a/src/components/subscription-payment-flow.tsx
+++ b/src/components/subscription-payment-flow.tsx
@@ -52,6 +52,7 @@ export default function SubscriptionPaymentFlow({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
   const [account, setAccount] = useState<AccountDetail>();
+  const [autoRenewalEnabled, setAutoRenewalEnabled] = useState(false);
 
   useEffect(() => {
     if (!login?.api) return;
@@ -60,6 +61,16 @@ export default function SubscriptionPaymentFlow({
       .then(setAccount)
       .catch((e) => console.error("Failed to load account info:", e));
   }, [login?.api]);
+
+  // Load the subscription so we know whether to save the card for off-session
+  // automatic renewals during a Revolut checkout.
+  useEffect(() => {
+    if (!login?.api) return;
+    login.api
+      .getSubscription(subscriptionId)
+      .then((s) => setAutoRenewalEnabled(s.auto_renewal_enabled))
+      .catch((e) => console.error("Failed to load subscription:", e));
+  }, [login?.api, subscriptionId]);
 
   const handlePaymentComplete = useCallback(() => {
     setPayment(undefined);
@@ -225,6 +236,7 @@ export default function SubscriptionPaymentFlow({
             payment={toVmPayment(payment)}
             account={account}
             onPaid={handlePaymentComplete}
+            saveCard={autoRenewalEnabled}
           />
         ) : (
           <div className="bg-cyber-panel-light p-4 rounded-sm space-y-2 text-center">


### PR DESCRIPTION
Companion to LNVPS/api#160 (Fixes LNVPS/api#159).

## Summary

When a subscription has `auto_renewal_enabled`, pass `savePaymentMethodFor: 'merchant'` to the Revolut card widget so the customer's card is saved for merchant-initiated (off-session) automatic renewals. The backend then captures the saved payment method on webhook completion and charges it automatically when the subscription is expiring.

## Changes

- `RevolutPayWidget` gains an optional `saveCard` prop; when set, `cardField.submit(...)` includes `savePaymentMethodFor: 'merchant'`.
- `SubscriptionPaymentFlow` loads the subscription and enables `saveCard` when `auto_renewal_enabled` is true.

## Notes

Card saving requires the embedded checkout widget (already used here) — the hosted checkout page does not support it. Validated end-to-end against the Revolut sandbox: the widget with `savePaymentMethodFor: 'merchant'` saves the card, after which the backend charges it off-session successfully.