### PR TITLE
fix(deps): commit bun.lock for @types/js-yaml

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "@tailwindcss/vite": "^4.1.18",
         "@types/bun": "^1.3.10",
         "@types/compression": "^1.8.1",
+        "@types/js-yaml": "^4.0.9",
         "@types/react": "^19.1.0",
         "@types/react-dom": "^19.1.0",
         "@vitejs/plugin-react": "^5.1.2",
@@ -355,6 +356,8 @@
     "@types/hoist-non-react-statics": ["@types/hoist-non-react-statics@3.3.7", "", { "dependencies": { "hoist-non-react-statics": "^3.3.0" }, "peerDependencies": { "@types/react": "*" } }, "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g=="],
 
     "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
+
+    "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 


### PR DESCRIPTION
`Build and Deploy` has failed on every push to `main` since 2026-07-25, six in a row, all with:

```
error: lockfile had changes, but lockfile is frozen
ERROR: process "/bin/sh -c bun install --frozen-lockfile --production" ... exit code: 1
```

`bfa3ff8` (2026-07-24) added `"@types/js-yaml": "^4.0.9"` to `devDependencies` and did not update `bun.lock`. `package.json` last changed in `bfa3ff8`; `bun.lock` last changed in `20259e1` on 2026-07-20.

Both `Dockerfile` stages run `bun install --frozen-lockfile` (the runner stage adds `--production`), and `--production` does not skip the lockfile-vs-manifest check, so the runner stage fails even though `@types/js-yaml` is a dev dependency.

Because `.github/workflows/build-deploy.yml` only pushes `registry.v0l.io/lnvps-web:latest` on a successful push to `main`, no image has been published since 2026-07-25 07:43 — the registry tag still holds a pre-catalog build. That is the actual cause of #23, and it is why #25 cannot be verified against production yet.

## The change

`bun install` with bun 1.3.14. Three lines, and nothing else moved:

```diff
         "@types/compression": "^1.8.1",
+        "@types/js-yaml": "^4.0.9",
         "@types/react": "^19.1.0",
```
```diff
+    "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/..."],
```

`@types/js-yaml` has no dependencies of its own, so there are no transitive additions. No existing resolution was bumped — `git diff --stat` is `bun.lock | 3 +++`.

## Verified

Reproduced the failure at `d45e3f5` first, then on this branch:

- `bun install --frozen-lockfile` → `Checked 318 installs across 392 packages (no changes)`
- `bun install --frozen-lockfile --production` against a bare `package.json` + `bun.lock` copy, i.e. the runner stage → 103 packages, no error
- `bun run build` completes (client, SSR, locale compile, skill index)

## Sequencing

This has to merge before #25, so #25 rebases onto a green base and CI can actually build it. Then merge #25 before the first image ships: deploying `main` alone would put five app pages in front of Google carrying `noindex,nofollow` in server-rendered HTML, and a crawled `noindex` costs a re-crawl cycle to undo.

Refs #23.
