### PR TITLE
feat(apps): add a public /apps catalog index route and sitemap entries (#24 items 3-4)

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -6,6 +6,39 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://lnvps.net/apps</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <!-- One entry per app in the catalog. Hand-maintained like the rest of this
+       file: add a line when an app is added. #18 replaces the whole file with a
+       generated one and should source these from /api/v1/apps. -->
+  <url>
+    <loc>https://lnvps.net/apps/1</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://lnvps.net/apps/2</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://lnvps.net/apps/3</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://lnvps.net/apps/4</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://lnvps.net/apps/5</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://lnvps.net/news</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -58,6 +58,10 @@ export interface AppLoaderData {
   app?: App;
 }
 
+export interface AppsLoaderData {
+  apps?: App[];
+}
+
 export function getNews() {
   return System.GetQuery("server-news")?.snapshot;
 }
@@ -145,4 +149,15 @@ export async function appLoader({
   const api = new LNVpsApi(ApiUrl ?? "", undefined, 5000);
   const app = await cached(`app_${id}`, () => api.getApp(id));
   return { app };
+}
+
+/**
+ * `/apps` is the public catalog listing, so like `/apps/:id` it has to
+ * server-render its content rather than fetch in an effect. Shares the `apps`
+ * cache entry with `homeLoader`, which fetches the same unauthenticated list.
+ */
+export async function appsLoader(): Promise<AppsLoaderData> {
+  const api = new LNVpsApi(ApiUrl ?? "", undefined, 5000);
+  const apps = await cached("apps", () => api.listApps());
+  return { apps };
 }

--- a/src/pages/apps.tsx
+++ b/src/pages/apps.tsx
@@ -1,0 +1,59 @@
+import { useLoaderData } from "react-router-dom";
+import { FormattedMessage, useIntl } from "react-intl";
+import Seo from "../components/seo";
+import { AppCard } from "./account-apps";
+import type { AppsLoaderData } from "../loaders";
+
+/**
+ * The public catalog listing. `/apps/:id` is the product page for one app; this
+ * is the page the launch copy's "browse the catalog" call to action points at,
+ * so it has to server-render a real title, h1 and the app list.
+ */
+export function AppsPage() {
+  const { formatMessage } = useIntl();
+  const { apps } = useLoaderData<AppsLoaderData>();
+
+  // The API returns the catalog in no particular order (today: 5, 3, 4, 2, 1),
+  // so sort before rendering — a listing that reshuffles between renders is
+  // worse for readers and gives crawlers a different page each fetch.
+  const catalog = apps ? [...apps].sort((a, b) => a.id - b.id) : [];
+
+  return (
+    <div className="flex flex-col gap-6">
+      {catalog.length > 0 ? (
+        <Seo
+          title={formatMessage({
+            defaultMessage: "Managed Apps — One-Click Nostr and Blossom Hosting",
+          })}
+          canonical="/apps"
+          description={formatMessage({
+            defaultMessage:
+              "Deploy a Nostr relay or a Blossom media server as a managed app on LNVPS. Provisioned in minutes with storage and TLS included — pay with Lightning, Bitcoin, or card.",
+          })}
+        />
+      ) : (
+        // No catalog means the fetch failed or returned nothing, and this page
+        // is then a heading with no product under it. Same reasoning as
+        // `/apps/:id`: keep an empty shell out of the index.
+        <Seo noindex={true} />
+      )}
+
+      <div className="flex flex-col gap-2">
+        <h1 className="m-0 text-2xl">
+          <FormattedMessage defaultMessage="Managed Apps" />
+        </h1>
+        <p className="m-0 text-cyber-muted">
+          <FormattedMessage defaultMessage="One-click Docker apps deployed on managed infrastructure." />
+        </p>
+      </div>
+
+      {catalog.length > 0 && (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {catalog.map((a) => (
+            <AppCard key={a.id} app={a} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -25,6 +25,7 @@ import { AccountReferralPage } from "./pages/account-referral.tsx";
 import { AccountSubscriptionsPage } from "./pages/account-subscriptions.tsx";
 import { AccountAppsPage } from "./pages/account-apps.tsx";
 import { AppPage } from "./pages/app.tsx";
+import { AppsPage } from "./pages/apps.tsx";
 import { AccountAppDeploymentPage } from "./pages/account-app-deployment.tsx";
 import { AccountSubscriptionPage } from "./pages/account-subscription.tsx";
 import { AccountSshKeysPage } from "./pages/account-ssh-keys.tsx";
@@ -32,6 +33,7 @@ import AccountLayout from "./pages/account-layout.tsx";
 import VmLayout from "./pages/vm-layout.tsx";
 import {
   appLoader,
+  appsLoader,
   homeLoader,
   newsLoader,
   newsPostLoader,
@@ -131,6 +133,11 @@ export const routes: RouteObject[] = [
       {
         path: "/order",
         element: <OrderPage />,
+      },
+      {
+        path: "/apps",
+        element: <AppsPage />,
+        loader: appsLoader,
       },
       {
         path: "/apps/:id",


### PR DESCRIPTION
Closes #24 (items 3 and 4). Items 1 and 2 are #25.

> **Merge order: #26 → #25 → this.** This branch is stacked on #25 (`e39cb08`), not `main`, because #25 touches `src/routes.tsx` and `src/loaders.ts` and this builds directly on `appLoader`. It needs a rebase onto `main` once #25 and #26 land, after which the diff here is one commit and four files. `build` is red for the `bun.lock` reason #26 fixes, not for anything in this PR.

## What was missing

The drafted launch post and both Managed App landing pages have a "browse the catalog" call to action with no URL behind it. `src/routes.tsx` had `/apps/:id` and `/account/apps` and no public listing — `lnvps.net/apps` returned 200 only because unmatched paths serve the SPA shell.

## What this does

**`appsLoader` + `/apps`.** The loader reuses the `apps` cache entry `homeLoader` already populates (`src/loaders.ts:24`), so the listing costs no extra upstream fetch. The route server-renders the title, `h1` and all five cards rather than filling in from an effect.

**Sorted by id.** `/api/v1/apps` returns the catalog unordered — today `5, 3, 4, 2, 1`. Without the sort the page is a different document on every fetch, which is bad for readers and worse for crawlers. (The homepage `AppsSection` has the same unsorted render; I left it alone rather than widen this PR.)

**Conditional `Seo`, same reasoning as #25.** Real title, description and canonical when the catalog resolved; `noindex` when it did not. `renderPage` returns 200 for every path, so without the fallback an unreachable catalog leaves a heading with no product under it crawlable.

**Sitemap: 5 URLs → 11.** `/apps` plus `/apps/1..5`. The file stays hand-maintained — #18 replaces it with a generated one and should source these from the API. Comment left in the file to that effect.

## Copy

The lead line reuses the existing homepage string verbatim, so it is already translated in all eleven locales. The `h1` and the two `Seo` strings are new and English-only until `locale:translate` runs — same as the new strings in #25. Jessica, the copy on this page is placeholder-grade and yours if you want it; it is deliberately factual rather than sold.

## Verified

Local production build (`bun run build` + `server/prod.ts` against `api.lnvps.net`) at `049b181`. Not verified against lnvps.net, which still serves a pre-catalog image (#23).

```
$ curl -s localhost:3114/apps
<title>Managed Apps — One-Click Nostr and Blossom Hosting | LNVPS</title>
<meta name="description" content="Deploy a Nostr relay or a Blossom media server as a managed app on LNVPS..."/>
<link rel="canonical" href="https://lnvps.net/apps"/>
<h1 class="m-0 text-2xl">Managed Apps</h1>
```

All five apps present in the server-rendered HTML, in id order, with prices from `CostLabel` — `€2/month` and `€3.50/month`, i.e. the integer minor units converted correctly.

| Path | title | h1 | robots |
|---|---|---|---|
| `/` | `Bitcoin Lightning VPS Hosting \| LNVPS` | `High-Performance VPS Hosting` | indexable |
| `/apps` | `Managed Apps — One-Click Nostr and Blossom Hosting \| LNVPS` | `Managed Apps` | indexable |
| `/apps/1` | `Strfry \| LNVPS` | `Strfry` | indexable |
| `/apps/9999` | `LNVPS` | none | `noindex,nofollow` |
| `/news` | `News and Product Updates \| LNVPS` | `LNVPS News and Product Updates` | indexable |

**The `noindex` fallback was tested, not assumed.** Rebuilt the SSR bundle against an unreachable `VITE_API_URL` and re-requested `/apps`: `noindex,nofollow`, no canonical, no app links, `h1` still rendered for a human who lands there.

`/sitemap.xml` parses as valid XML and serves 11 URLs. `tsc --noEmit` clean. `bun run lint` has the one pre-existing error at `server/prod.ts:13` that I did not touch. Headless Chrome shows no React hydration warnings and all five cards after hydration.

Came from the `general` channel — `f5894ea9-44c7-56fb-bd9b-6e3e671e4bc1`.
