### PR TITLE
feat(apps): sell the catalog page and link it from the homepage

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -50,6 +50,9 @@
   "/tiBYY": {
     "defaultMessage": "Continue with {provider}"
   },
+  "0ALykI": {
+    "defaultMessage": "Managed Apps — One-Click Nostr and Blossom Hosting"
+  },
   "0Azlrb": {
     "defaultMessage": "Manage"
   },
@@ -242,6 +245,9 @@
   "6UfYVI": {
     "defaultMessage": "High-performance VPS hosting with flexible payments — Bitcoin Lightning or card."
   },
+  "6axKu6": {
+    "defaultMessage": "Deploy {name} as a managed app on LNVPS — pay with Lightning, Bitcoin, or card."
+  },
   "6hEevT": {
     "defaultMessage": "Set default"
   },
@@ -277,6 +283,9 @@
   },
   "7fbBqG": {
     "defaultMessage": "Cancel payment"
+  },
+  "7jdMye": {
+    "defaultMessage": "Stopping keeps your data"
   },
   "7q/bs/": {
     "defaultMessage": "Renew now"
@@ -371,6 +380,9 @@
   "ASrBq8": {
     "defaultMessage": "Passkeys"
   },
+  "ATA6lA": {
+    "defaultMessage": "Running in Dublin, Ireland. If you want the whole machine rather than the app on it, the <vps>VPS</vps> is still there — Managed Apps do not replace it."
+  },
   "AUlRcp": {
     "defaultMessage": "Nostr Wallet Connect"
   },
@@ -422,6 +434,9 @@
   "BnoVvl": {
     "defaultMessage": "Terms of Service for LNVPS. Read our usage policies, acceptable use guidelines, and service terms."
   },
+  "BnvK83": {
+    "defaultMessage": "From {price}."
+  },
   "Bwqhmd": {
     "defaultMessage": "Firewall"
   },
@@ -448,6 +463,9 @@
   },
   "DFLJpz": {
     "defaultMessage": "New monthly renewal cost: {cost}"
+  },
+  "DTd1bi": {
+    "defaultMessage": "Lightning, on-chain, or card"
   },
   "DU+LLZ": {
     "defaultMessage": "Referral"
@@ -1088,6 +1106,9 @@
   "Y/tMXU": {
     "defaultMessage": "Waiting for payment. This is applied automatically once it confirms."
   },
+  "YSgfWQ": {
+    "defaultMessage": "Managed Apps: run a relay without running a server"
+  },
   "YWjrby": {
     "defaultMessage": "Account alerts only, such as VM expiration. We never send marketing messages."
   },
@@ -1129,6 +1150,9 @@
   },
   "ZshmbW": {
     "defaultMessage": "This component only supports on-chain payments"
+  },
+  "ZvAN+v": {
+    "defaultMessage": "Stopping a deployment scales it to zero and keeps the storage. Your relay's database is still there when you start it again. Only deleting removes it."
   },
   "aPcXT9": {
     "defaultMessage": "Payouts are batched with other on-chain referrers into one transaction once your balance clears the minimum. Your share of the network fee is deducted from your balance. Mainnet addresses only."
@@ -1175,11 +1199,17 @@
   "c0b5XV": {
     "defaultMessage": "Rate"
   },
+  "c5aQL+": {
+    "defaultMessage": "Pick an app, give it a name, pay. It comes up on its own hostname with TLS already working — no OS to patch, no Docker to configure, no certificate to renew."
+  },
   "c78ZVJ": {
     "defaultMessage": "DNS changes may take up to 24–48 hours to propagate"
   },
   "cGedMc": {
     "defaultMessage": "Instant — scan or pay a one-time invoice"
+  },
+  "cJzoWc": {
+    "defaultMessage": "Its own hostname, TLS included"
   },
   "cM5n1C": {
     "defaultMessage": "End Time (optional)"
@@ -1358,6 +1388,9 @@
   "huqKGl": {
     "defaultMessage": "Create account"
   },
+  "i2/SmH": {
+    "defaultMessage": "Billing works like a VPS subscription, with no setup fee on any app."
+  },
   "i5j1QG": {
     "defaultMessage": "App #{id}"
   },
@@ -1400,6 +1433,9 @@
   "jYLOYR": {
     "defaultMessage": "{n, plural, one {# day} other {# days}}"
   },
+  "jd19T+": {
+    "defaultMessage": "Every deployment gets {host} with a certificate issued automatically. Bring your own domain and point a CNAME at it — we serve that too, with its own certificate, issued once DNS resolves."
+  },
   "jf7fbc": {
     "defaultMessage": "None set — add one"
   },
@@ -1429,6 +1465,9 @@
   },
   "kSjQ3a": {
     "defaultMessage": "by {initiatedBy}"
+  },
+  "kdK1BE": {
+    "defaultMessage": "Deploy a Nostr relay or a Blossom media server as a managed app on LNVPS. Provisioned in minutes with storage and TLS included — pay with Lightning, Bitcoin, or card."
   },
   "kfr95E": {
     "defaultMessage": "Address Line 1"
@@ -1651,6 +1690,9 @@
   },
   "sAJryD": {
     "defaultMessage": "VAT and fees are estimated; the exact amount is confirmed at payment."
+  },
+  "sOF2lj": {
+    "defaultMessage": "View full README"
   },
   "sQu9nL": {
     "defaultMessage": "SSH Key"

--- a/src/pages/apps.tsx
+++ b/src/pages/apps.tsx
@@ -1,8 +1,38 @@
-import { useLoaderData } from "react-router-dom";
+import type { ReactNode } from "react";
+import { Link, useLoaderData } from "react-router-dom";
 import { FormattedMessage, useIntl } from "react-intl";
 import Seo from "../components/seo";
+import { CostAmount } from "../components/cost";
 import { AppCard } from "./account-apps";
+import { CostPlanIntervalType, type App } from "../api";
 import type { AppsLoaderData } from "../loaders";
+
+/**
+ * The cheapest thing on the page, for the lead's price anchor.
+ *
+ * Only comparable prices are considered: a single currency, and a one-month
+ * billing interval so the "/month" the label prints is the real one. Returns
+ * undefined when the catalog does not satisfy that, so the caller drops the
+ * clause rather than anchoring on a number that means something else.
+ */
+function cheapestMonthly(apps: App[]): App | undefined {
+  const monthly = apps.filter(
+    (a) =>
+      a.interval_type === CostPlanIntervalType.MONTH && a.interval_amount === 1,
+  );
+  if (monthly.length === 0) return undefined;
+  if (new Set(monthly.map((a) => a.currency)).size > 1) return undefined;
+  return monthly.reduce((min, a) => (a.amount < min.amount ? a : min));
+}
+
+function Block({ title, children }: { title: ReactNode; children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <h2 className="m-0 text-base text-cyber-text-bright">{title}</h2>
+      <p className="m-0 text-sm text-cyber-muted">{children}</p>
+    </div>
+  );
+}
 
 /**
  * The public catalog listing. `/apps/:id` is the product page for one app; this
@@ -17,6 +47,7 @@ export function AppsPage() {
   // so sort before rendering — a listing that reshuffles between renders is
   // worse for readers and gives crawlers a different page each fetch.
   const catalog = apps ? [...apps].sort((a, b) => a.id - b.id) : [];
+  const cheapest = cheapestMonthly(catalog);
 
   return (
     <div className="flex flex-col gap-6">
@@ -32,18 +63,40 @@ export function AppsPage() {
           })}
         />
       ) : (
-        // No catalog means the fetch failed or returned nothing, and this page
-        // is then a heading with no product under it. Same reasoning as
-        // `/apps/:id`: keep an empty shell out of the index.
+        // No catalog means the fetch failed or returned nothing. The copy below
+        // still renders, but a catalog page with no catalog is broken, not a
+        // page worth ranking. Same reasoning as `/apps/:id`: keep it out of the
+        // index rather than serve a soft 404 (`renderPage` returns 200 always).
         <Seo noindex={true} />
       )}
 
       <div className="flex flex-col gap-2">
         <h1 className="m-0 text-2xl">
-          <FormattedMessage defaultMessage="Managed Apps" />
+          <FormattedMessage defaultMessage="Managed Apps: run a relay without running a server" />
         </h1>
-        <p className="m-0 text-cyber-muted">
-          <FormattedMessage defaultMessage="One-click Docker apps deployed on managed infrastructure." />
+        <p className="m-0 max-w-prose text-cyber-muted">
+          <FormattedMessage defaultMessage="Pick an app, give it a name, pay. It comes up on its own hostname with TLS already working — no OS to patch, no Docker to configure, no certificate to renew." />
+          {cheapest && (
+            <>
+              {" "}
+              <FormattedMessage
+                defaultMessage="From {price}."
+                values={{
+                  price: (
+                    <CostAmount
+                      cost={{
+                        currency: cheapest.currency,
+                        amount: cheapest.amount,
+                        interval_type: cheapest.interval_type,
+                      }}
+                      converted={false}
+                      taxable
+                    />
+                  ),
+                }}
+              />
+            </>
+          )}
         </p>
       </div>
 
@@ -54,6 +107,50 @@ export function AppsPage() {
           ))}
         </div>
       )}
+
+      <div className="grid gap-6 sm:grid-cols-3">
+        <Block
+          title={
+            <FormattedMessage defaultMessage="Its own hostname, TLS included" />
+          }
+        >
+          <FormattedMessage
+            defaultMessage="Every deployment gets {host} with a certificate issued automatically. Bring your own domain and point a CNAME at it — we serve that too, with its own certificate, issued once DNS resolves."
+            values={{
+              host: (
+                <span className="font-mono text-cyber-accent">
+                  your-name.ie.apps.lnvps.cloud
+                </span>
+              ),
+            }}
+          />
+        </Block>
+        <Block
+          title={<FormattedMessage defaultMessage="Stopping keeps your data" />}
+        >
+          <FormattedMessage defaultMessage="Stopping a deployment scales it to zero and keeps the storage. Your relay's database is still there when you start it again. Only deleting removes it." />
+        </Block>
+        <Block
+          title={
+            <FormattedMessage defaultMessage="Lightning, on-chain, or card" />
+          }
+        >
+          <FormattedMessage defaultMessage="Billing works like a VPS subscription, with no setup fee on any app." />
+        </Block>
+      </div>
+
+      <p className="m-0 max-w-prose text-sm text-cyber-muted">
+        <FormattedMessage
+          defaultMessage="Running in Dublin, Ireland. If you want the whole machine rather than the app on it, the <vps>VPS</vps> is still there — Managed Apps do not replace it."
+          values={{
+            vps: (chunks: ReactNode) => (
+              <Link to="/" className="text-cyber-primary hover:underline">
+                {chunks}
+              </Link>
+            ),
+          }}
+        />
+      </p>
     </div>
   );
 }

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -396,16 +396,21 @@ function VpsOffersSection() {
 function AppsSection() {
   const { apps } = useLoaderData<HomeLoaderData>();
   if (!apps || apps.length === 0) return null;
+  // Same sort as /apps — the API returns the catalog unordered, and the two
+  // pages showing it in different orders reads as a broken site.
+  const catalog = [...apps].sort((a, b) => a.id - b.id);
   return (
     <>
       <SectionHeading>
-        <FormattedMessage defaultMessage="Apps" />
+        <Link to="/apps" className="hover:text-cyber-primary transition-colors">
+          <FormattedMessage defaultMessage="Apps" />
+        </Link>
       </SectionHeading>
       <p className="text-cyber-muted">
         <FormattedMessage defaultMessage="One-click Docker apps deployed on managed infrastructure." />
       </p>
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {apps.map((a) => (
+        {catalog.map((a) => (
           <AppCard key={a.id} app={a} />
         ))}
       </div>


### PR DESCRIPTION
Jessica's `/apps` copy, built as written (`OUTBOX/LNVPS_APPS_INDEX_COPY.md`), plus the homepage link and sort she and Alejandra both asked for.

Follow-up to #29. Nothing in #29 is re-opened — `<title>`, description, canonical and the `noindex` fallback are unchanged.

## What changed

**`src/pages/apps.tsx`**
- `h1` → "Managed Apps: run a relay without running a server" — verbatim the long-form post title, so the post, both landing pages and this page read as one launch.
- Lead replaced. The old line ("One-click Docker apps deployed on managed infrastructure.") was accurate and answered no question a buyer has.
- Three blocks below the grid: hostname/TLS, stopping keeps data, payment methods.
- Closing line with the region and a link back to the VPS.

**`src/pages/home.tsx`**
- `AppsSection` heading links to `/apps`. The site has no nav, so the catalog was reachable only from the sitemap and inbound CTAs.
- Same sort by id as `/apps`, so the two pages agree on order.

**`src/locales/en.json`** — `bun run locale:extract`. Also picks up four strings from #25/#29 that were never extracted.

## The price anchor

"From €2/month" is computed, not typed. `cheapestMonthly()` filters to a single currency and a one-month interval, then takes the minimum, and returns `undefined` otherwise so the clause drops rather than anchoring on a number that means something different. It renders through `CostAmount`, the same component `CostLabel` delegates to when no conversion applies (`src/components/cost.tsx:36`) — not a second converter.

"No setup fee on any app" stays a literal. It is true across all five apps today (`setup_amount: 0`), but it is a claim about the catalog that no guard can watch, so it stays copy rather than looking computed.

## Verified

At `0f81fa8`, on a local production build (`bun run build` + `server/prod.ts`), `git rev-parse HEAD` confirmed in the same shell.

- `bunx tsc --noEmit` clean; `bun run build` clean; tree clean after both.
- `bun run lint`: 1 error, 21 warnings — identical to `main`. The error is the pre-existing `server/prod.ts:13`.
- SSR against `api.lnvps.net`: title and `h1` as above, three `h2`s, five cards in id order `/apps/1`…`/apps/5`, no `robots` meta.
- SSR lead renders `From €2/month.` — computed, matching all five catalog entries.
- Homepage SSR: `href="/apps"` on the heading, cards in id order.
- **Guard, mixed currency:** SSR bundle rebuilt against a local fixture serving EUR-monthly + USD-monthly. Clause dropped; paragraph ends on "no certificate to renew."; page still indexable and cards still render.
- **Guard, mixed interval:** fixture with EUR 1-month, EUR 1-year, EUR 3-month → renders `From €2/month.`, considering only the one-month entries.
- **`noindex` fallback:** SSR bundle rebuilt against an unreachable API → `robots: noindex,nofollow`, default title, no cards, price clause dropped.
- Rendered at 1280 and at 390 with device-metrics emulation: blocks are a three-column strip on `sm:` and stack below; `document.documentElement.scrollWidth === innerWidth === 390`, no element past the viewport.

Not verified on lnvps.net — it still serves a pre-catalog image while #23 is open.

## Not done here

New strings are English-only. `locale:translate` needs a local Ollama and `http://localhost:11434` is not reachable from this machine.

Channel: general (#f5894ea9-44c7-56fb-bd9b-6e3e671e4bc1)