### PR TITLE
feat(home): rewrite the apps section lead and name it Managed Apps

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -227,9 +227,6 @@
   "5y2qWO": {
     "defaultMessage": "Connecting..."
   },
-  "62gWV4": {
-    "defaultMessage": "One-click Docker apps deployed on managed infrastructure."
-  },
   "6Auf1w": {
     "defaultMessage": "We couldn't complete the login. Please try again."
   },
@@ -1493,6 +1490,9 @@
   "lP4qIQ": {
     "defaultMessage": "Card details"
   },
+  "lYEj5M": {
+    "defaultMessage": "Managed Apps"
+  },
   "lhCavK": {
     "defaultMessage": "Tick “Save this card” when paying with Revolut to store a card here for future payments and automatic renewals."
   },
@@ -1558,6 +1558,9 @@
   },
   "nWQFic": {
     "defaultMessage": "Renew"
+  },
+  "nWxtS5": {
+    "defaultMessage": "Nostr relays and Blossom media servers, run for you — each on its own hostname with TLS already working, no server to patch. See the full <catalog>catalog</catalog>."
   },
   "nidU9E": {
     "defaultMessage": "{rate} commission"

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -403,11 +403,20 @@ function AppsSection() {
     <>
       <SectionHeading>
         <Link to="/apps" className="hover:text-cyber-primary transition-colors">
-          <FormattedMessage defaultMessage="Apps" />
+          <FormattedMessage defaultMessage="Managed Apps" />
         </Link>
       </SectionHeading>
       <p className="text-cyber-muted">
-        <FormattedMessage defaultMessage="One-click Docker apps deployed on managed infrastructure." />
+        <FormattedMessage
+          defaultMessage="Nostr relays and Blossom media servers, run for you — each on its own hostname with TLS already working, no server to patch. See the full <catalog>catalog</catalog>."
+          values={{
+            catalog: (chunks: ReactNode) => (
+              <Link to="/apps" className="text-cyber-primary hover:underline">
+                {chunks}
+              </Link>
+            ),
+          }}
+        />
       </p>
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {catalog.map((a) => (


### PR DESCRIPTION
Follow-up to #30, which linked the homepage `AppsSection` heading to `/apps` but left the section's own copy alone. The homepage still opened with "One-click Docker apps deployed on managed infrastructure." — the exact line Jessica replaced on `/apps`, one click from the page that no longer uses it.

Copy from Jessica (`OUTBOX/LNVPS_APPS_INDEX_COPY.md`, "Addendum — homepage AppsSection"), built as written.

## What changed — `src/pages/home.tsx:405`

- Heading `Apps` → `Managed Apps`. The `/apps` link from #30 stays on it.
- Lead replaced with: *"Nostr relays and Blossom media servers, run for you — each on its own hostname with TLS already working, no server to patch. See the full [catalog](/apps)."*

The inline `/apps` link is deliberately not redundant with the heading link: body-copy anchor text is worth more to a crawler than a heading wrapper, and a reader scanning the section text should not have to go find the heading.

No price in the lead. The cards directly below carry their own through `CostLabel`, so a second anchor would be a number to keep correct for nothing.

## Left alone, on purpose

Two other "One-click Docker apps" strings stay — `src/components/account-nav.tsx:46` and `src/pages/account-apps.tsx:145`. Both are logged-in account UI behind auth, not marketing surface. Those are the only other occurrences of the phrase in `src/`; I did not check outside `src/`.

## Verified

At `77a5db2`, on a local production build (`bun run build` + `server/prod.ts` against `api.lnvps.net`), `git rev-parse HEAD` confirmed in the same shell.

- `bunx tsc --noEmit` clean; `bun run build` clean; tree clean after both.
- `bun run lint`: 1 error, 21 warnings — identical to `main`, none added. The error is the pre-existing `server/prod.ts:13`.
- Homepage SSR: heading renders `Managed Apps` wrapped in `href="/apps"`, lead renders with the inline `catalog` anchor to `/apps`, two `/apps` links total, cards in id order `/apps/1`…`/apps/5`. The retired string does not appear in the served HTML.
- Rendered at 1280 with device-metrics emulation: heading and lead read as written, inline link visibly distinct from body text.
- At 390: `document.documentElement.scrollWidth === innerWidth === 390`, no element past the viewport.

Not verified on lnvps.net — it still serves a pre-catalog image while #23 is open.

## Not done here

Both new strings are English-only. `locale:translate` needs a local Ollama and `http://localhost:11434` is not reachable from this machine. Extraction also drops the retired lead's key from `en.json`; the other ten locale files keep it as a dead entry until the translate step regenerates them.

Channel: general (#f5894ea9-44c7-56fb-bd9b-6e3e671e4bc1)