### PR TITLE
feat(apps): Product/Offer structured data on /apps/:id

### DIFF
--- a/src/components/head-context.tsx
+++ b/src/components/head-context.tsx
@@ -119,11 +119,26 @@ export function serializeHead(tags: HeadTags): string {
   }
   for (const json of tags.scripts) {
     parts.push(
-      `<script ${MANAGED_ATTR}="true" type="application/ld+json">${json}</script>`,
+      `<script ${MANAGED_ATTR}="true" type="application/ld+json">${escapeJsonLd(json)}</script>`,
     );
   }
 
   return parts.join("\n");
+}
+
+/**
+ * Escape `<` for injection inside a `<script>` element.
+ *
+ * HTML entities are not decoded inside `<script>`, so `escapeHtml` cannot be
+ * used here — only the JSON string escape works. `JSON.stringify` leaves `<`
+ * alone, so a value containing `</script>` would otherwise close the element
+ * early. It also only ever emits `<` inside a string literal, where the escape
+ * is legal and decodes back to the same character, so consumers see no change.
+ *
+ * The client path needs nothing: it assigns `el.textContent` (see above).
+ */
+function escapeJsonLd(json: string): string {
+  return json.replace(/</g, "\\u003c");
 }
 
 function escapeHtml(s: string): string {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -50,9 +50,6 @@
   "/tiBYY": {
     "defaultMessage": "Continue with {provider}"
   },
-  "06VvI6": {
-    "defaultMessage": "Pyramid Hosting — Managed Community Nostr Relay"
-  },
   "0ALykI": {
     "defaultMessage": "Managed Apps — One-Click Nostr and Blossom Hosting"
   },
@@ -212,9 +209,6 @@
   "5FWCVu": {
     "defaultMessage": "Your encrypted NIP-17 message history with support."
   },
-  "5Lp2F6": {
-    "defaultMessage": "Host your own Blossom and NIP-96 media server. Route96 on LNVPS comes up on its own hostname with TLS and 25 GB storage."
-  },
   "5QYdPU": {
     "defaultMessage": "Start Time"
   },
@@ -362,9 +356,6 @@
   "9p3I3O": {
     "defaultMessage": "Confirming"
   },
-  "9siBxf": {
-    "defaultMessage": "{price}/month, pay with Lightning."
-  },
   "9uOFF3": {
     "defaultMessage": "Overview"
   },
@@ -400,9 +391,6 @@
   },
   "AxlcnX": {
     "defaultMessage": "This inbox is no longer monitored, so new messages can't be sent here. For support, please open a ticket from the Support tab."
-  },
-  "B07gFS": {
-    "defaultMessage": "Strfry Hosting — Managed Nostr Relay"
   },
   "B3YjIQ": {
     "defaultMessage": "Save this key now — it CANNOT be recovered."
@@ -652,9 +640,6 @@
   },
   "HqRNN8": {
     "defaultMessage": "Support"
-  },
-  "Hx0H/Y": {
-    "defaultMessage": "Route96 — Managed Blossom Media Server Hosting"
   },
   "I3JhPS": {
     "defaultMessage": "Network"
@@ -1076,9 +1061,6 @@
   "VffztH": {
     "defaultMessage": "last used {date}"
   },
-  "VivwdJ": {
-    "defaultMessage": "Host a Pyramid community relay on LNVPS — members invite members, and you run no server. Own hostname, TLS and 20 GB storage."
-  },
   "VtKAyJ": {
     "defaultMessage": "{count} / {max} rules"
   },
@@ -1109,9 +1091,6 @@
   "XD6788": {
     "defaultMessage": "Setup fee:"
   },
-  "XGEIm8": {
-    "defaultMessage": "HAVEN Hosting — Managed Personal Nostr Relay"
-  },
   "XNiOLB": {
     "defaultMessage": "Failed to send message. Please try again."
   },
@@ -1138,9 +1117,6 @@
   },
   "Ysr8td": {
     "defaultMessage": "Earned"
-  },
-  "YxAN6U": {
-    "defaultMessage": "Run a strfry relay on LNVPS with no server to manage — up in minutes on its own hostname, TLS and 10 GB storage included."
   },
   "YyojwF": {
     "defaultMessage": "Configuration Changes:"
@@ -1171,9 +1147,6 @@
   },
   "ZshmbW": {
     "defaultMessage": "This component only supports on-chain payments"
-  },
-  "ZueY58": {
-    "defaultMessage": "Run nostr-rs-relay on LNVPS — a light Rust and SQLite relay, up in minutes on its own hostname with TLS and 10 GB storage."
   },
   "ZvAN+v": {
     "defaultMessage": "Stopping a deployment scales it to zero and keeps the storage. Your relay's database is still there when you start it again. Only deleting removes it."
@@ -1403,9 +1376,6 @@
   "hMzcSq": {
     "defaultMessage": "Messages"
   },
-  "hQYhc1": {
-    "defaultMessage": "nostr-rs-relay Hosting — Managed Nostr Relay"
-  },
   "hX8VXF": {
     "defaultMessage": "Monthly Uptime (Past 12 Months)"
   },
@@ -1414,9 +1384,6 @@
   },
   "huqKGl": {
     "defaultMessage": "Create account"
-  },
-  "hzas+A": {
-    "defaultMessage": "HAVEN on LNVPS is a personal relay with private, chat, inbox and outbox sections plus its own Blossom media server. 30 GB storage, TLS included."
   },
   "i2/SmH": {
     "defaultMessage": "Billing works like a VPS subscription, with no setup fee on any app."
@@ -1501,9 +1468,6 @@
   },
   "kfr95E": {
     "defaultMessage": "Address Line 1"
-  },
-  "kr8jZp": {
-    "defaultMessage": "{price}/month."
   },
   "ku+mDU": {
     "defaultMessage": "State"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -50,6 +50,9 @@
   "/tiBYY": {
     "defaultMessage": "Continue with {provider}"
   },
+  "06VvI6": {
+    "defaultMessage": "Pyramid Hosting — Managed Community Nostr Relay"
+  },
   "0ALykI": {
     "defaultMessage": "Managed Apps — One-Click Nostr and Blossom Hosting"
   },
@@ -209,6 +212,9 @@
   "5FWCVu": {
     "defaultMessage": "Your encrypted NIP-17 message history with support."
   },
+  "5Lp2F6": {
+    "defaultMessage": "Host your own Blossom and NIP-96 media server. Route96 on LNVPS comes up on its own hostname with TLS and 25 GB storage."
+  },
   "5QYdPU": {
     "defaultMessage": "Start Time"
   },
@@ -356,6 +362,9 @@
   "9p3I3O": {
     "defaultMessage": "Confirming"
   },
+  "9siBxf": {
+    "defaultMessage": "{price}/month, pay with Lightning."
+  },
   "9uOFF3": {
     "defaultMessage": "Overview"
   },
@@ -391,6 +400,9 @@
   },
   "AxlcnX": {
     "defaultMessage": "This inbox is no longer monitored, so new messages can't be sent here. For support, please open a ticket from the Support tab."
+  },
+  "B07gFS": {
+    "defaultMessage": "Strfry Hosting — Managed Nostr Relay"
   },
   "B3YjIQ": {
     "defaultMessage": "Save this key now — it CANNOT be recovered."
@@ -640,6 +652,9 @@
   },
   "HqRNN8": {
     "defaultMessage": "Support"
+  },
+  "Hx0H/Y": {
+    "defaultMessage": "Route96 — Managed Blossom Media Server Hosting"
   },
   "I3JhPS": {
     "defaultMessage": "Network"
@@ -1061,6 +1076,9 @@
   "VffztH": {
     "defaultMessage": "last used {date}"
   },
+  "VivwdJ": {
+    "defaultMessage": "Host a Pyramid community relay on LNVPS — members invite members, and you run no server. Own hostname, TLS and 20 GB storage."
+  },
   "VtKAyJ": {
     "defaultMessage": "{count} / {max} rules"
   },
@@ -1091,6 +1109,9 @@
   "XD6788": {
     "defaultMessage": "Setup fee:"
   },
+  "XGEIm8": {
+    "defaultMessage": "HAVEN Hosting — Managed Personal Nostr Relay"
+  },
   "XNiOLB": {
     "defaultMessage": "Failed to send message. Please try again."
   },
@@ -1117,6 +1138,9 @@
   },
   "Ysr8td": {
     "defaultMessage": "Earned"
+  },
+  "YxAN6U": {
+    "defaultMessage": "Run a strfry relay on LNVPS with no server to manage — up in minutes on its own hostname, TLS and 10 GB storage included."
   },
   "YyojwF": {
     "defaultMessage": "Configuration Changes:"
@@ -1147,6 +1171,9 @@
   },
   "ZshmbW": {
     "defaultMessage": "This component only supports on-chain payments"
+  },
+  "ZueY58": {
+    "defaultMessage": "Run nostr-rs-relay on LNVPS — a light Rust and SQLite relay, up in minutes on its own hostname with TLS and 10 GB storage."
   },
   "ZvAN+v": {
     "defaultMessage": "Stopping a deployment scales it to zero and keeps the storage. Your relay's database is still there when you start it again. Only deleting removes it."
@@ -1376,6 +1403,9 @@
   "hMzcSq": {
     "defaultMessage": "Messages"
   },
+  "hQYhc1": {
+    "defaultMessage": "nostr-rs-relay Hosting — Managed Nostr Relay"
+  },
   "hX8VXF": {
     "defaultMessage": "Monthly Uptime (Past 12 Months)"
   },
@@ -1384,6 +1414,9 @@
   },
   "huqKGl": {
     "defaultMessage": "Create account"
+  },
+  "hzas+A": {
+    "defaultMessage": "HAVEN on LNVPS is a personal relay with private, chat, inbox and outbox sections plus its own Blossom media server. 30 GB storage, TLS included."
   },
   "i2/SmH": {
     "defaultMessage": "Billing works like a VPS subscription, with no setup fee on any app."
@@ -1468,6 +1501,9 @@
   },
   "kfr95E": {
     "defaultMessage": "Address Line 1"
+  },
+  "kr8jZp": {
+    "defaultMessage": "{price}/month."
   },
   "ku+mDU": {
     "defaultMessage": "State"

--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -12,7 +12,7 @@ import CostLabel, { CostAmount } from "../components/cost";
 import DeployAppForm from "../components/deploy-app-form";
 import Markdown from "../components/markdown";
 import { fetchReadme } from "../utils/readme";
-import { appSeo } from "../utils/app-seo";
+import { appJsonLd } from "../utils/app-seo";
 import { highlightYaml } from "../utils/yaml-highlight";
 import { AppIcon, deploymentStatus } from "./account-apps";
 import type { AppLoaderData } from "../loaders";
@@ -70,7 +70,7 @@ function ReadmeSection({
 
 export function AppPage() {
   const login = useLogin();
-  const intl = useIntl();
+  const { formatMessage } = useIntl();
   const { id } = useParams<{ id: string }>();
   const appId = Number(id);
   // Seeded by appLoader so the first (server) render already has the app, and
@@ -102,20 +102,15 @@ export function AppPage() {
     }
   }, [login?.api, appId]);
 
-  // Search-facing strings for the apps we have written them for; the API's own
-  // display_name and description are the fallback for anything else.
-  const seo = app ? appSeo(app, intl) : undefined;
-
   return (
     <div className="flex flex-col gap-6">
       {app ? (
         <Seo
-          title={seo?.title ?? app.display_name}
+          title={app.display_name}
           canonical={`/apps/${app.id}`}
           description={
-            seo?.description ??
             app.description ??
-            intl.formatMessage(
+            formatMessage(
               {
                 defaultMessage:
                   "Deploy {name} as a managed app on LNVPS — pay with Lightning, Bitcoin, or card.",
@@ -123,7 +118,7 @@ export function AppPage() {
               { name: app.display_name },
             )
           }
-          jsonLd={seo?.jsonLd}
+          jsonLd={appJsonLd(app)}
         />
       ) : (
         // The loader found no app: either the id does not exist or the catalog

--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -12,6 +12,7 @@ import CostLabel, { CostAmount } from "../components/cost";
 import DeployAppForm from "../components/deploy-app-form";
 import Markdown from "../components/markdown";
 import { fetchReadme } from "../utils/readme";
+import { appSeo } from "../utils/app-seo";
 import { highlightYaml } from "../utils/yaml-highlight";
 import { AppIcon, deploymentStatus } from "./account-apps";
 import type { AppLoaderData } from "../loaders";
@@ -69,7 +70,7 @@ function ReadmeSection({
 
 export function AppPage() {
   const login = useLogin();
-  const { formatMessage } = useIntl();
+  const intl = useIntl();
   const { id } = useParams<{ id: string }>();
   const appId = Number(id);
   // Seeded by appLoader so the first (server) render already has the app, and
@@ -101,15 +102,20 @@ export function AppPage() {
     }
   }, [login?.api, appId]);
 
+  // Search-facing strings for the apps we have written them for; the API's own
+  // display_name and description are the fallback for anything else.
+  const seo = app ? appSeo(app, intl) : undefined;
+
   return (
     <div className="flex flex-col gap-6">
       {app ? (
         <Seo
-          title={app.display_name}
+          title={seo?.title ?? app.display_name}
           canonical={`/apps/${app.id}`}
           description={
+            seo?.description ??
             app.description ??
-            formatMessage(
+            intl.formatMessage(
               {
                 defaultMessage:
                   "Deploy {name} as a managed app on LNVPS — pay with Lightning, Bitcoin, or card.",
@@ -117,6 +123,7 @@ export function AppPage() {
               { name: app.display_name },
             )
           }
+          jsonLd={seo?.jsonLd}
         />
       ) : (
         // The loader found no app: either the id does not exist or the catalog

--- a/src/utils/app-seo.ts
+++ b/src/utils/app-seo.ts
@@ -98,15 +98,29 @@ const APP_SEO: Record<string, AppSeoEntry> = {
 };
 
 /**
- * Billing period unit for `UnitPriceSpecification.unitText`, one per interval
- * the API can return (`src/api.ts:29-33`). Typed on the enum, so a new interval
- * type there is a type error here rather than an undefined in the markup.
+ * Billing period unit per interval the API can return (`src/api.ts:29-33`).
+ *
+ * `code` is the UN/CEFACT Common Code for `unitCode`, which is the property
+ * schema.org names for this job: `billingDuration` is "a Duration or a Number
+ * (in which case the unit of measurement … is specified by the `unitCode`
+ * property)", and `billingIncrement`'s "unit of measurement is specified by the
+ * `unitCode` property". We emit Numbers, so the code is the carrier and
+ * `unitText` is the documented fallback for when a code is unavailable — kept
+ * alongside because it costs nothing and is what a human reading the markup
+ * sees.
+ *
+ * Codes from UN/CEFACT Rec 20 Annex I, quantity "time": `DAY` day, `MON`
+ * month, `ANN` year.
+ *
+ * Typed on the enum, so a new interval type is a type error here rather than
+ * an undefined in the markup.
  */
-const BILLING_UNIT_TEXT: Record<CostPlanIntervalType, string> = {
-  [CostPlanIntervalType.DAY]: "DAY",
-  [CostPlanIntervalType.MONTH]: "MONTH",
-  [CostPlanIntervalType.YEAR]: "YEAR",
-};
+const BILLING_UNIT: Record<CostPlanIntervalType, { code: string; text: string }> =
+  {
+    [CostPlanIntervalType.DAY]: { code: "DAY", text: "DAY" },
+    [CostPlanIntervalType.MONTH]: { code: "MON", text: "MONTH" },
+    [CostPlanIntervalType.YEAR]: { code: "ANN", text: "YEAR" },
+  };
 
 /**
  * Whether the app bills at exactly one month, so "/month" means what it says.
@@ -219,7 +233,8 @@ export function appSeo(app: App, intl: IntlShape): AppSeo {
               // false rather than merely weaker.
               billingDuration: app.interval_amount,
               billingIncrement: 1,
-              unitText: BILLING_UNIT_TEXT[app.interval_type],
+              unitCode: BILLING_UNIT[app.interval_type].code,
+              unitText: BILLING_UNIT[app.interval_type].text,
             },
           },
         }

--- a/src/utils/app-seo.ts
+++ b/src/utils/app-seo.ts
@@ -97,7 +97,22 @@ const APP_SEO: Record<string, AppSeoEntry> = {
   },
 };
 
-/** Whether the app bills at exactly one month, so "/month" means what it says. */
+/**
+ * Billing period unit for `UnitPriceSpecification.unitText`, one per interval
+ * the API can return (`src/api.ts:29-33`). Typed on the enum, so a new interval
+ * type there is a type error here rather than an undefined in the markup.
+ */
+const BILLING_UNIT_TEXT: Record<CostPlanIntervalType, string> = {
+  [CostPlanIntervalType.DAY]: "DAY",
+  [CostPlanIntervalType.MONTH]: "MONTH",
+  [CostPlanIntervalType.YEAR]: "YEAR",
+};
+
+/**
+ * Whether the app bills at exactly one month, so "/month" means what it says.
+ * Only the written price clause needs this — the structured data derives its
+ * period from the interval instead of dropping it.
+ */
 function isMonthly(app: App): boolean {
   return (
     app.interval_type === CostPlanIntervalType.MONTH && app.interval_amount === 1
@@ -197,16 +212,14 @@ export function appSeo(app: App, intl: IntlShape): AppSeo {
               // Ex-VAT, matching what the page shows logged out. Never
               // conditional on the VAT toggle: this is what a crawler sees.
               valueAddedTaxIncluded: false,
-              // Billing period only when it is exactly one month. A
-              // monthly-labelled figure that is really annual is worse than
-              // a bare price, which is still valid on its own.
-              ...(isMonthly(app)
-                ? {
-                    billingDuration: 1,
-                    billingIncrement: 1,
-                    unitText: "MONTH",
-                  }
-                : {}),
+              // The billing period is derived, not guessed: `interval_type`
+              // and `interval_amount` say exactly what it is. Omitting it for
+              // a yearly app would advertise a bare recurring figure with no
+              // period, which reads as a total — the one drop that would be
+              // false rather than merely weaker.
+              billingDuration: app.interval_amount,
+              billingIncrement: 1,
+              unitText: BILLING_UNIT_TEXT[app.interval_type],
             },
           },
         }

--- a/src/utils/app-seo.ts
+++ b/src/utils/app-seo.ts
@@ -1,0 +1,217 @@
+import { defineMessages, type IntlShape } from "react-intl";
+import { CostPlanIntervalType, type App } from "../api";
+import { smallestUnitScale } from "./currency";
+
+/** Matches `SITE_URL` in `src/components/seo.tsx:5`, for absolute schema URLs. */
+const SITE_URL = "https://lnvps.net";
+
+/**
+ * Search-facing title and description for a catalog app.
+ *
+ * `/apps/:id` took both from the API, which gives card blurbs — "Strfry",
+ * "High performance nostr relay". Accurate on a card, and useless as the thing
+ * a search result shows: no "hosting", no "managed", no price. This overrides
+ * them on the public product page only; the API `description` keeps its job as
+ * the card blurb and as the paragraph under the h1.
+ *
+ * Keyed on `app.name`, the API's URL/DNS-safe slug (`src/api.ts:622`) — ids
+ * renumber, slugs do not. An app with no entry keeps today's behaviour, so a
+ * sixth app in the catalog ships with a working page and no code change here.
+ *
+ * Copy: `OUTBOX/LNVPS_APP_PAGE_SEO_STRINGS.md`.
+ */
+const m = defineMessages({
+  strfryTitle: { defaultMessage: "Strfry Hosting — Managed Nostr Relay" },
+  strfryDescription: {
+    defaultMessage:
+      "Run a strfry relay on LNVPS with no server to manage — up in minutes on its own hostname, TLS and 10 GB storage included.",
+  },
+  route96Title: {
+    defaultMessage: "Route96 — Managed Blossom Media Server Hosting",
+  },
+  route96Description: {
+    defaultMessage:
+      "Host your own Blossom and NIP-96 media server. Route96 on LNVPS comes up on its own hostname with TLS and 25 GB storage.",
+  },
+  nostrRsRelayTitle: {
+    defaultMessage: "nostr-rs-relay Hosting — Managed Nostr Relay",
+  },
+  nostrRsRelayDescription: {
+    defaultMessage:
+      "Run nostr-rs-relay on LNVPS — a light Rust and SQLite relay, up in minutes on its own hostname with TLS and 10 GB storage.",
+  },
+  pyramidTitle: {
+    defaultMessage: "Pyramid Hosting — Managed Community Nostr Relay",
+  },
+  pyramidDescription: {
+    defaultMessage:
+      "Host a Pyramid community relay on LNVPS — members invite members, and you run no server. Own hostname, TLS and 20 GB storage.",
+  },
+  havenTitle: { defaultMessage: "HAVEN Hosting — Managed Personal Nostr Relay" },
+  havenDescription: {
+    defaultMessage:
+      "HAVEN on LNVPS is a personal relay with private, chat, inbox and outbox sections plus its own Blossom media server. 30 GB storage, TLS included.",
+  },
+  // The price tail is per app, not one shared string: four apps close on the
+  // payment method, HAVEN closes on the price because its description is
+  // already at the character limit.
+  priceWithLightning: { defaultMessage: "{price}/month, pay with Lightning." },
+  priceOnly: { defaultMessage: "{price}/month." },
+});
+
+type Message = (typeof m)[keyof typeof m];
+
+interface AppSeoEntry {
+  title: Message;
+  /** Ends on a complete sentence; the price clause is appended, not embedded. */
+  description: Message;
+  /** Template for the price clause, taking a formatted `price`. */
+  priceSuffix: Message;
+}
+
+const APP_SEO: Record<string, AppSeoEntry> = {
+  strfry: {
+    title: m.strfryTitle,
+    description: m.strfryDescription,
+    priceSuffix: m.priceWithLightning,
+  },
+  route96: {
+    title: m.route96Title,
+    description: m.route96Description,
+    priceSuffix: m.priceWithLightning,
+  },
+  "nostr-rs-relay": {
+    title: m.nostrRsRelayTitle,
+    description: m.nostrRsRelayDescription,
+    priceSuffix: m.priceWithLightning,
+  },
+  "pyramid-relay": {
+    title: m.pyramidTitle,
+    description: m.pyramidDescription,
+    priceSuffix: m.priceWithLightning,
+  },
+  "haven-relay": {
+    title: m.havenTitle,
+    description: m.havenDescription,
+    priceSuffix: m.priceOnly,
+  },
+};
+
+/** Whether the app bills at exactly one month, so "/month" means what it says. */
+function isMonthly(app: App): boolean {
+  return (
+    app.interval_type === CostPlanIntervalType.MONTH && app.interval_amount === 1
+  );
+}
+
+/**
+ * The recurring price in standard units as a plain decimal, for structured
+ * data. Undefined for BTC: amounts there are millisats, which two decimal
+ * places cannot express — better no `price` than "0.00".
+ */
+function standardUnitPrice(app: App): string | undefined {
+  if (app.currency === "BTC") return undefined;
+  return (app.amount / smallestUnitScale(app.currency)).toFixed(2);
+}
+
+/**
+ * The recurring price as a display string.
+ *
+ * A `<meta>` content attribute is a string, so `CostAmount` — a component —
+ * cannot render it; this formats the same way it does (`src/components/cost.tsx:127-133`)
+ * so the tag and the cards print the same figure.
+ *
+ * **Ex-VAT deliberately, no gross-up.** A meta tag is what a crawler and a link
+ * preview see and both are logged out, so a logged-in reader's VAT toggle must
+ * not change what the page advertises. This is the opposite of the `/apps`
+ * lead, which sits beside cards that move with the toggle.
+ */
+function monthlyPrice(app: App, intl: IntlShape): string | undefined {
+  if (!isMonthly(app)) return undefined;
+  // Same reason as standardUnitPrice: `style: "currency"` rounds a millisat
+  // figure to "BTC 0.00", so drop the clause rather than print a false price.
+  if (app.currency === "BTC") return undefined;
+  return intl.formatNumber(app.amount / smallestUnitScale(app.currency), {
+    style: "currency",
+    currency: app.currency,
+    trailingZeroDisplay: "stripIfInteger",
+  });
+}
+
+export interface AppSeo {
+  /** Undefined when the app has no map entry; callers fall back to the API. */
+  title?: string;
+  description?: string;
+  /** Always present: structured data does not depend on a map entry. */
+  jsonLd: object;
+}
+
+/**
+ * Title, meta description and `Product`/`Offer` structured data for one app.
+ *
+ * The title and description are undefined for an app with no map entry, so the
+ * caller keeps the API strings. The structured data is not — it is built from
+ * the app's own price and identity, which every app has, so a sixth app gets a
+ * `Product`/`Offer` without a copy entry. Shape per `LNVPS/web#32`.
+ */
+export function appSeo(app: App, intl: IntlShape): AppSeo {
+  const entry = APP_SEO[app.name];
+
+  const price = entry ? monthlyPrice(app, intl) : undefined;
+  const title = entry ? intl.formatMessage(entry.title) : undefined;
+  const description = entry
+    ? (() => {
+        const base = intl.formatMessage(entry.description);
+        return price
+          ? `${base} ${intl.formatMessage(entry.priceSuffix, { price })}`
+          : base;
+      })()
+    : undefined;
+
+  const url = `${SITE_URL}/apps/${app.id}`;
+  const offerPrice = standardUnitPrice(app);
+  // The written description when we have one, so the rich result and the meta
+  // tag on the same page cannot say different things.
+  const schemaDescription = description ?? app.description;
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    // The product is the app, not the search-facing title: "Strfry", not
+    // "Strfry Hosting — Managed Nostr Relay".
+    name: app.display_name,
+    ...(schemaDescription ? { description: schemaDescription } : {}),
+    url,
+    brand: { "@type": "Brand", name: "LNVPS" },
+    ...(offerPrice
+      ? {
+          offers: {
+            "@type": "Offer",
+            url,
+            availability: "https://schema.org/InStock",
+            price: offerPrice,
+            priceCurrency: app.currency,
+            priceSpecification: {
+              "@type": "UnitPriceSpecification",
+              price: offerPrice,
+              priceCurrency: app.currency,
+              // Ex-VAT, matching what the page shows logged out. Never
+              // conditional on the VAT toggle: this is what a crawler sees.
+              valueAddedTaxIncluded: false,
+              // Billing period only when it is exactly one month. A
+              // monthly-labelled figure that is really annual is worse than
+              // a bare price, which is still valid on its own.
+              ...(isMonthly(app)
+                ? {
+                    billingDuration: 1,
+                    billingIncrement: 1,
+                    unitText: "MONTH",
+                  }
+                : {}),
+            },
+          },
+        }
+      : {}),
+  };
+
+  return { title, description, jsonLd };
+}

--- a/src/utils/app-seo.ts
+++ b/src/utils/app-seo.ts
@@ -1,101 +1,8 @@
-import { defineMessages, type IntlShape } from "react-intl";
 import { CostPlanIntervalType, type App } from "../api";
 import { smallestUnitScale } from "./currency";
 
 /** Matches `SITE_URL` in `src/components/seo.tsx:5`, for absolute schema URLs. */
 const SITE_URL = "https://lnvps.net";
-
-/**
- * Search-facing title and description for a catalog app.
- *
- * `/apps/:id` took both from the API, which gives card blurbs — "Strfry",
- * "High performance nostr relay". Accurate on a card, and useless as the thing
- * a search result shows: no "hosting", no "managed", no price. This overrides
- * them on the public product page only; the API `description` keeps its job as
- * the card blurb and as the paragraph under the h1.
- *
- * Keyed on `app.name`, the API's URL/DNS-safe slug (`src/api.ts:622`) — ids
- * renumber, slugs do not. An app with no entry keeps today's behaviour, so a
- * sixth app in the catalog ships with a working page and no code change here.
- *
- * Copy: `OUTBOX/LNVPS_APP_PAGE_SEO_STRINGS.md`.
- */
-const m = defineMessages({
-  strfryTitle: { defaultMessage: "Strfry Hosting — Managed Nostr Relay" },
-  strfryDescription: {
-    defaultMessage:
-      "Run a strfry relay on LNVPS with no server to manage — up in minutes on its own hostname, TLS and 10 GB storage included.",
-  },
-  route96Title: {
-    defaultMessage: "Route96 — Managed Blossom Media Server Hosting",
-  },
-  route96Description: {
-    defaultMessage:
-      "Host your own Blossom and NIP-96 media server. Route96 on LNVPS comes up on its own hostname with TLS and 25 GB storage.",
-  },
-  nostrRsRelayTitle: {
-    defaultMessage: "nostr-rs-relay Hosting — Managed Nostr Relay",
-  },
-  nostrRsRelayDescription: {
-    defaultMessage:
-      "Run nostr-rs-relay on LNVPS — a light Rust and SQLite relay, up in minutes on its own hostname with TLS and 10 GB storage.",
-  },
-  pyramidTitle: {
-    defaultMessage: "Pyramid Hosting — Managed Community Nostr Relay",
-  },
-  pyramidDescription: {
-    defaultMessage:
-      "Host a Pyramid community relay on LNVPS — members invite members, and you run no server. Own hostname, TLS and 20 GB storage.",
-  },
-  havenTitle: { defaultMessage: "HAVEN Hosting — Managed Personal Nostr Relay" },
-  havenDescription: {
-    defaultMessage:
-      "HAVEN on LNVPS is a personal relay with private, chat, inbox and outbox sections plus its own Blossom media server. 30 GB storage, TLS included.",
-  },
-  // The price tail is per app, not one shared string: four apps close on the
-  // payment method, HAVEN closes on the price because its description is
-  // already at the character limit.
-  priceWithLightning: { defaultMessage: "{price}/month, pay with Lightning." },
-  priceOnly: { defaultMessage: "{price}/month." },
-});
-
-type Message = (typeof m)[keyof typeof m];
-
-interface AppSeoEntry {
-  title: Message;
-  /** Ends on a complete sentence; the price clause is appended, not embedded. */
-  description: Message;
-  /** Template for the price clause, taking a formatted `price`. */
-  priceSuffix: Message;
-}
-
-const APP_SEO: Record<string, AppSeoEntry> = {
-  strfry: {
-    title: m.strfryTitle,
-    description: m.strfryDescription,
-    priceSuffix: m.priceWithLightning,
-  },
-  route96: {
-    title: m.route96Title,
-    description: m.route96Description,
-    priceSuffix: m.priceWithLightning,
-  },
-  "nostr-rs-relay": {
-    title: m.nostrRsRelayTitle,
-    description: m.nostrRsRelayDescription,
-    priceSuffix: m.priceWithLightning,
-  },
-  "pyramid-relay": {
-    title: m.pyramidTitle,
-    description: m.pyramidDescription,
-    priceSuffix: m.priceWithLightning,
-  },
-  "haven-relay": {
-    title: m.havenTitle,
-    description: m.havenDescription,
-    priceSuffix: m.priceOnly,
-  },
-};
 
 /**
  * Billing period unit per interval the API can return (`src/api.ts:29-33`).
@@ -123,17 +30,6 @@ const BILLING_UNIT: Record<CostPlanIntervalType, { code: string; text: string }>
   };
 
 /**
- * Whether the app bills at exactly one month, so "/month" means what it says.
- * Only the written price clause needs this — the structured data derives its
- * period from the interval instead of dropping it.
- */
-function isMonthly(app: App): boolean {
-  return (
-    app.interval_type === CostPlanIntervalType.MONTH && app.interval_amount === 1
-  );
-}
-
-/**
  * The recurring price in standard units as a plain decimal, for structured
  * data. Undefined for BTC: amounts there are millisats, which two decimal
  * places cannot express — better no `price` than "0.00".
@@ -144,71 +40,21 @@ function standardUnitPrice(app: App): string | undefined {
 }
 
 /**
- * The recurring price as a display string.
+ * `Product`/`Offer` structured data for one app. Shape per `LNVPS/web#32`.
  *
- * A `<meta>` content attribute is a string, so `CostAmount` — a component —
- * cannot render it; this formats the same way it does (`src/components/cost.tsx:127-133`)
- * so the tag and the cards print the same figure.
- *
- * **Ex-VAT deliberately, no gross-up.** A meta tag is what a crawler and a link
- * preview see and both are logged out, so a logged-in reader's VAT toggle must
- * not change what the page advertises. This is the opposite of the `/apps`
- * lead, which sits beside cards that move with the toggle.
+ * Built from the app's own price and identity, which every app has, so a new
+ * catalog app gets a rich result with no code change here. The description is
+ * the API's, the same string the page renders under the h1, so the rich result
+ * and the meta tag cannot say different things.
  */
-function monthlyPrice(app: App, intl: IntlShape): string | undefined {
-  if (!isMonthly(app)) return undefined;
-  // Same reason as standardUnitPrice: `style: "currency"` rounds a millisat
-  // figure to "BTC 0.00", so drop the clause rather than print a false price.
-  if (app.currency === "BTC") return undefined;
-  return intl.formatNumber(app.amount / smallestUnitScale(app.currency), {
-    style: "currency",
-    currency: app.currency,
-    trailingZeroDisplay: "stripIfInteger",
-  });
-}
-
-export interface AppSeo {
-  /** Undefined when the app has no map entry; callers fall back to the API. */
-  title?: string;
-  description?: string;
-  /** Always present: structured data does not depend on a map entry. */
-  jsonLd: object;
-}
-
-/**
- * Title, meta description and `Product`/`Offer` structured data for one app.
- *
- * The title and description are undefined for an app with no map entry, so the
- * caller keeps the API strings. The structured data is not — it is built from
- * the app's own price and identity, which every app has, so a sixth app gets a
- * `Product`/`Offer` without a copy entry. Shape per `LNVPS/web#32`.
- */
-export function appSeo(app: App, intl: IntlShape): AppSeo {
-  const entry = APP_SEO[app.name];
-
-  const price = entry ? monthlyPrice(app, intl) : undefined;
-  const title = entry ? intl.formatMessage(entry.title) : undefined;
-  const description = entry
-    ? (() => {
-        const base = intl.formatMessage(entry.description);
-        return price
-          ? `${base} ${intl.formatMessage(entry.priceSuffix, { price })}`
-          : base;
-      })()
-    : undefined;
-
+export function appJsonLd(app: App): object {
   const url = `${SITE_URL}/apps/${app.id}`;
   const offerPrice = standardUnitPrice(app);
-  // The written description when we have one, so the rich result and the meta
-  // tag on the same page cannot say different things.
-  const schemaDescription = description ?? app.description;
-  const jsonLd = {
+  return {
     "@context": "https://schema.org",
     "@type": "Product",
-    // The product is the app, not the search-facing title: "Strfry", not
-    // "Strfry Hosting — Managed Nostr Relay".
     name: app.display_name,
-    ...(schemaDescription ? { description: schemaDescription } : {}),
+    ...(app.description ? { description: app.description } : {}),
     url,
     brand: { "@type": "Brand", name: "LNVPS" },
     ...(offerPrice
@@ -229,8 +75,7 @@ export function appSeo(app: App, intl: IntlShape): AppSeo {
               // The billing period is derived, not guessed: `interval_type`
               // and `interval_amount` say exactly what it is. Omitting it for
               // a yearly app would advertise a bare recurring figure with no
-              // period, which reads as a total — the one drop that would be
-              // false rather than merely weaker.
+              // period, which reads as a total.
               billingDuration: app.interval_amount,
               billingIncrement: 1,
               unitCode: BILLING_UNIT[app.interval_type].code,
@@ -240,6 +85,4 @@ export function appSeo(app: App, intl: IntlShape): AppSeo {
         }
       : {}),
   };
-
-  return { title, description, jsonLd };
 }


### PR DESCRIPTION
Closes #32. From the `general` channel thread on the launch SEO gates.

**Reworked at `fb6954e`** per Alejandra: the hardcoded per-slug title/description map is gone. `/apps/:id` keeps the API's own `display_name` and `description` for `<title>` and meta, exactly as it did before this branch. What survives is the part that is *derived* rather than hand-written.

## What changed

Three things, all mechanical:

**1. `Product`/`Offer` structured data on `/apps/:id`** — `src/utils/app-seo.ts` (new, 88 lines) exports one function, `appJsonLd(app)`. Built from the app's own name, description, price, currency and billing interval, so a sixth catalog app gets a rich result with no code change here. `Product.description` is the API's — the same string the page renders under the h1 — so the rich result and the meta tag cannot say different things.

A BTC-priced app gets no `offers` at all: amounts are millisats and `Offer.price` wants two decimals, so the alternative is advertising `0.00`.

Ex-VAT, and `taxable` is deliberately not threaded through this path. A rich result is what a logged-out crawler sees; a logged-in reader's VAT toggle must not change what the page advertises.

**2. The billing period is derived, not dropped** (`be54a70`, `a008c9d`). `UnitPriceSpecification` has a field for the period and `interval_amount` / `interval_type` say exactly what it is. Omitting it made a yearly app advertise a bare recurring `price` with no period, which reads as a total. The period is carried in `unitCode` (`DAY` / `MON` / `ANN`, UN/CEFACT Rec 20 Annex I), with `unitText` alongside as the documented free-text fallback. `BILLING_UNIT` is typed on `CostPlanIntervalType`, so a new interval in `src/api.ts:29-33` is a type error here rather than an `undefined` in the markup.

Codes cross-checked against three independent republications of Rec 20 (Peppol BIS 3.0, OASIS UBL 2.1 `UnitOfMeasureCode-2.1.gc`, CIFConsulting mirror) — UNECE's own files 403 to this machine, so this is convergence, not the primary document. Every property and value type validated offline against `schemaorg-current-https.jsonld`; method in `RESEARCH/JSONLD_VOCABULARY_VALIDATION.md`. **That says nothing about whether Google renders it** — the Rich Results Test needs a live URL, so that check stays open until after a deploy.

**3. `690eeed` — escape `<` in SSR-injected JSON-LD.** `serializeHead` interpolated serialised JSON straight into `<script type="application/ld+json">` (`src/components/head-context.tsx:120-124`) while its three sibling branches escape (`:106`, `:110`, `:116`). `JSON.stringify` leaves `<` alone, so any value containing `</script>` closed the element early. HTML entities are not decoded inside `<script>`, so `escapeHtml` is the wrong tool — the JSON string escape is. Kept as its own commit.

Not an open hole before this PR: the two existing call sites are the static homepage schema and news events filtered to our own pubkey. This change is what alters that, by putting admin-edited `display_name` and `description` into that path. The client path needs nothing — `:89` assigns `el.textContent`.

One character is enough because `application/ld+json` is never *executed*: a crawler reads it as text and `JSON.parse` accepts U+2028/U+2029 inside strings. React Router escapes five in its hydration payload because that one is JavaScript. The only thing that can end a `<script>` element early is `<`, and escaping it also makes `<!--` unreachable.

## Verified

At `fb6954e`, `git rev-parse HEAD` checked in the same shell as each run.

- `bunx tsc --noEmit` clean; `bun run build` clean; `bun run locale:extract` reproduces `src/locales/en.json` byte-for-byte (net zero against `main` — the ten map strings were added and removed on this branch).
- SSR from `server/prod.ts` + curl on `/apps/1`: `<title>Strfry | LNVPS</title>`, `<h1>Strfry</h1>`, one `ld+json` block carrying `Product` → `Offer` → `UnitPriceSpecification` with `billingDuration: 1`, `billingIncrement: 1`, `unitCode: "MON"`. No `robots` meta — still indexable.
- `/apps/99999`: `noindex,nofollow`, default title, no structured data. Unchanged.
- `bun run lint`: unchanged from `main` — the one error is the pre-existing `server/prod.ts:13`.

Fixture results for yearly / 3-month / 30-day / BTC intervals and the `</script>` injection case are in the `fe073b6` revision of this description; the code paths they cover are untouched by `fb6954e`.

## Not in this PR

- **The `h1` is still `Strfry`.** Jessica is right that it is the wrong greeting for someone arriving from a hosting search; it is layout, not a string, and it goes after #19.
- **Search-facing titles.** Removed here by design. If we want them, they come from the API so a new app inherits the behaviour — not from a table in the front end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
