### PR TITLE
fix(copy): describe the product, not the ecosystem, in five main strings

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2,6 +2,9 @@
   "++XeyK": {
     "defaultMessage": "Nostr key"
   },
+  "+1wksq": {
+    "defaultMessage": "Stopping a deployment scales it to zero and keeps the storage. Your data is still there when you start it again. Only deleting removes it."
+  },
   "+3NyB6": {
     "defaultMessage": "Outbound"
   },
@@ -49,9 +52,6 @@
   },
   "/tiBYY": {
     "defaultMessage": "Continue with {provider}"
-  },
-  "0ALykI": {
-    "defaultMessage": "Managed Apps — One-Click Nostr and Blossom Hosting"
   },
   "0Azlrb": {
     "defaultMessage": "Manage"
@@ -556,6 +556,9 @@
   },
   "FazwRl": {
     "defaultMessage": "Try again"
+  },
+  "Ff9LAg": {
+    "defaultMessage": "Software we run for you — each app on its own hostname with TLS already working, no server to patch. Nostr relays and Blossom media servers in the <catalog>catalog</catalog> today."
   },
   "FlypmR": {
     "defaultMessage": "Add an email address below"
@@ -1103,9 +1106,6 @@
   "Y/tMXU": {
     "defaultMessage": "Waiting for payment. This is applied automatically once it confirms."
   },
-  "YSgfWQ": {
-    "defaultMessage": "Managed Apps: run a relay without running a server"
-  },
   "YWjrby": {
     "defaultMessage": "Account alerts only, such as VM expiration. We never send marketing messages."
   },
@@ -1147,9 +1147,6 @@
   },
   "ZshmbW": {
     "defaultMessage": "This component only supports on-chain payments"
-  },
-  "ZvAN+v": {
-    "defaultMessage": "Stopping a deployment scales it to zero and keeps the storage. Your relay's database is still there when you start it again. Only deleting removes it."
   },
   "aPcXT9": {
     "defaultMessage": "Payouts are batched with other on-chain referrers into one transaction once your balance clears the minimum. Your share of the network fee is deducted from your balance. Mainnet addresses only."
@@ -1463,9 +1460,6 @@
   "kSjQ3a": {
     "defaultMessage": "by {initiatedBy}"
   },
-  "kdK1BE": {
-    "defaultMessage": "Deploy a Nostr relay or a Blossom media server as a managed app on LNVPS. Provisioned in minutes with storage and TLS included — pay with Lightning, Bitcoin, or card."
-  },
   "kfr95E": {
     "defaultMessage": "Address Line 1"
   },
@@ -1517,6 +1511,9 @@
   "m4QgXr": {
     "defaultMessage": "{days, plural, one {# day left} other {# days left}}"
   },
+  "m4xBT/": {
+    "defaultMessage": "Managed Apps: run the software without running the server"
+  },
   "mIuuiJ": {
     "defaultMessage": "Service Status and Uptime"
   },
@@ -1559,8 +1556,8 @@
   "nWQFic": {
     "defaultMessage": "Renew"
   },
-  "nWxtS5": {
-    "defaultMessage": "Nostr relays and Blossom media servers, run for you — each on its own hostname with TLS already working, no server to patch. See the full <catalog>catalog</catalog>."
+  "naCpPX": {
+    "defaultMessage": "Deploy an app on LNVPS — up in minutes on its own hostname, TLS and storage included, no OS to patch. Nostr relays and Blossom media servers today."
   },
   "nidU9E": {
     "defaultMessage": "{rate} commission"
@@ -1693,6 +1690,9 @@
   },
   "sAJryD": {
     "defaultMessage": "VAT and fees are estimated; the exact amount is confirmed at payment."
+  },
+  "sE5lVR": {
+    "defaultMessage": "Managed App Hosting — No Server to Run"
   },
   "sOF2lj": {
     "defaultMessage": "View full README"

--- a/src/pages/apps.tsx
+++ b/src/pages/apps.tsx
@@ -54,12 +54,12 @@ export function AppsPage() {
       {catalog.length > 0 ? (
         <Seo
           title={formatMessage({
-            defaultMessage: "Managed Apps — One-Click Nostr and Blossom Hosting",
+            defaultMessage: "Managed App Hosting — No Server to Run",
           })}
           canonical="/apps"
           description={formatMessage({
             defaultMessage:
-              "Deploy a Nostr relay or a Blossom media server as a managed app on LNVPS. Provisioned in minutes with storage and TLS included — pay with Lightning, Bitcoin, or card.",
+              "Deploy an app on LNVPS — up in minutes on its own hostname, TLS and storage included, no OS to patch. Nostr relays and Blossom media servers today.",
           })}
         />
       ) : (
@@ -72,7 +72,7 @@ export function AppsPage() {
 
       <div className="flex flex-col gap-2">
         <h1 className="m-0 text-2xl">
-          <FormattedMessage defaultMessage="Managed Apps: run a relay without running a server" />
+          <FormattedMessage defaultMessage="Managed Apps: run the software without running the server" />
         </h1>
         <p className="m-0 max-w-prose text-cyber-muted">
           <FormattedMessage defaultMessage="Pick an app, give it a name, pay. It comes up on its own hostname with TLS already working — no OS to patch, no Docker to configure, no certificate to renew." />
@@ -128,7 +128,7 @@ export function AppsPage() {
         <Block
           title={<FormattedMessage defaultMessage="Stopping keeps your data" />}
         >
-          <FormattedMessage defaultMessage="Stopping a deployment scales it to zero and keeps the storage. Your relay's database is still there when you start it again. Only deleting removes it." />
+          <FormattedMessage defaultMessage="Stopping a deployment scales it to zero and keeps the storage. Your data is still there when you start it again. Only deleting removes it." />
         </Block>
         <Block
           title={

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -408,7 +408,7 @@ function AppsSection() {
       </SectionHeading>
       <p className="text-cyber-muted">
         <FormattedMessage
-          defaultMessage="Nostr relays and Blossom media servers, run for you — each on its own hostname with TLS already working, no server to patch. See the full <catalog>catalog</catalog>."
+          defaultMessage="Software we run for you — each app on its own hostname with TLS already working, no server to patch. Nostr relays and Blossom media servers in the <catalog>catalog</catalog> today."
           values={{
             catalog: (chunks: ReactNode) => (
               <Link to="/apps" className="text-cyber-primary hover:underline">


### PR DESCRIPTION
Closes #37. From the `lnvps` channel thread (`f5894ea9-44c7-56fb-bd9b-6e3e671e4bc1`) on the launch SEO gates.

Copy-only. Five `defaultMessage`s that described managed app hosting as a Nostr-relay product, where the behaviour they describe is true of every app in the catalog. Ecosystem-neutral in the title, ecosystem-specific one clause down — "Nostr relay" and "Blossom media server" survive in every string that had them; none of them leads.

Copy is Jessica's, verbatim from `OUTBOX/LNVPS_WEB37_DENOSTR_STRINGS.md`. Five, not four: `apps.tsx:131` was folded in by Alejandra at 07:35 ([comment](https://github.com/LNVPS/web/issues/37#issuecomment-5088562688)).

## What changed

| Where | Was | Now |
|---|---|---|
| `src/pages/apps.tsx:57` | `<title>` — 50 chars | 38, **46** with the ` \| LNVPS` that `src/components/seo.tsx:36` appends |
| `src/pages/apps.tsx:62` | meta description — 166 chars | **147** |
| `src/pages/apps.tsx:75` | `h1` — "run a relay without running a server" | "run the software without running the server" |
| `src/pages/home.tsx:411` | `AppsSection` lead | ecosystem clause moved after the general one |
| `src/pages/apps.tsx:131` | "Your **relay's** database is still there" | "Your **data** is still there" |

The description was over the ~155 that renders, so it is being truncated in results today. The trade for getting under it is dropping "pay with Lightning, Bitcoin, or card" — payment methods are in the page body and on both use-case landing pages.

`home.tsx:411` keeps the `<catalog>` chunk tag unchanged, so the `values={{ catalog: … }}` handler below it needs no edit and both `/apps` links survive — the `SectionHeading` wrapper at `:405` and the inline anchor.

Nothing else in the diff. The empty-catalog branch at `apps.tsx:69` still carries `<Seo noindex>`; no route, loader or `robots` behaviour is touched.

## Locales

All five are `defaultMessage`s, so each edit changes its formatjs hash id. `bun run locale:extract` is in the same commit: `src/locales/en.json` drops `0ALykI`, `kdK1BE`, `YSgfWQ`, `nWxtS5`, `ZvAN+v` and gains five new ids. Net zero keys.

Nothing translated is lost — Jessica checked all ten translated locales (`ar`, `de`, `es`, `fr`, `ja`, `ko`, `pt`, `ru`, `tr`, `zh`) by hash-id lookup, and none carried any of the five old ids.

## Verified

At `b8e6920`, rebased on `b4ace06` (#33). `git rev-parse HEAD` checked in the same shell as each run.

- `bunx tsc --noEmit` clean. `bun run build` clean. `bun run locale:extract` re-run on top of the edits reproduces `en.json` byte-for-byte.
- SSR from `server/prod.ts` + curl. `/apps`: `<title>Managed App Hosting — No Server to Run | LNVPS</title>`, `<h1>Managed Apps: run the software without running the server</h1>`, `<meta name="description" content="Deploy an app on LNVPS — …">`. `/`: the new lead renders with the catalog link intact.
- `bun run lint` not claimed — it exits 1 on the pre-existing `@ts-ignore` at `server/prod.ts:13`, untouched here.

There is no test framework in this repo, so the checks above are the whole verification surface.

