### PR TITLE
feat(apps): show a deployment's real size and let customers resize it

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -698,9 +698,45 @@ export interface AppDeployment {
   status_message?: string;
   /** Subscription this deployment is billed under (renew via the subscription endpoints). */
   subscription_id?: number;
+  /**
+   * Size as a multiple of the catalog app's base footprint and price; `1` is
+   * the base app. Raised via the upgrade endpoints, never lowered.
+   */
+  resource_multiplier: number;
+  /**
+   * Effective resources with `resource_multiplier` already applied — the API
+   * pre-multiplies so the UI never has to. Showing the catalog app's figures
+   * for an upgraded deployment displays a size the customer is not running.
+   */
+  cpu_milli: number;
+  memory_bytes: number;
+  storage_bytes: number;
   /** Current customer-supplied config field values (secrets never exposed). */
   config?: Record<string, string>;
   created: string;
+}
+
+/** Resize a deployment to a larger multiple of its app's base size. */
+export interface AppUpgradeRequest {
+  resource_multiplier: number;
+}
+
+/**
+ * Largest size a deployment may be upgraded to, as a multiple of the base app.
+ * Mirrors `MAX_RESOURCE_MULTIPLIER` in the API (`lnvps_api/src/api/apps.rs`),
+ * which rejects anything above it with a 400.
+ */
+export const MAX_RESOURCE_MULTIPLIER = 16;
+
+export interface AppUpgradeQuote {
+  /** Net pro-rated amount payable now (before tax/fees) for the rest of the period. */
+  cost_difference: Price;
+  /** What a full period costs at the new size, from the next renewal. */
+  new_renewal_cost: Price;
+  /** Credit for time already paid for at the current size. */
+  discount: Price;
+  tax: Price;
+  processing_fee: Price;
 }
 
 /** Update a deployment's name, custom domain and/or config (config replaces wholesale). */
@@ -1048,6 +1084,56 @@ export class LNVpsApi {
   async stopAppDeployment(id: number) {
     const { data } = await this.#handleResponse<ApiResponse<AppDeployment>>(
       await this.#req(`/api/v1/app-deployments/${id}/stop`, "PATCH"),
+    );
+    return data;
+  }
+
+  /**
+   * Price a resize without charging anything. `method` sets the currency the
+   * quote comes back in. Rejects a multiplier that is not strictly greater than
+   * the current one, is above {@link MAX_RESOURCE_MULTIPLIER}, or belongs to a
+   * deployment with no paid period to prorate against.
+   */
+  async getAppUpgradeQuote(
+    id: number,
+    req: AppUpgradeRequest,
+    method?: string,
+  ) {
+    const methodParam = method ? `?method=${method}` : "";
+    const { data } = await this.#handleResponse<ApiResponse<AppUpgradeQuote>>(
+      await this.#req(
+        `/api/v1/app-deployments/${id}/upgrade-quote${methodParam}`,
+        "POST",
+        req,
+      ),
+    );
+    return data;
+  }
+
+  /**
+   * Start a resize by creating its payment. The deployment is only resized once
+   * this settles, so an abandoned upgrade leaves it untouched.
+   */
+  async createAppUpgradePayment(
+    id: number,
+    req: AppUpgradeRequest,
+    method?: string,
+    opts?: { paymentMethodId?: number },
+  ) {
+    const params = new URLSearchParams();
+    if (method !== undefined) params.set("method", method);
+    if (opts?.paymentMethodId !== undefined) {
+      params.set("payment_method_id", opts.paymentMethodId.toString());
+    }
+    const query = params.toString() ? `?${params.toString()}` : "";
+    const { data } = await this.#handleResponse<
+      ApiResponse<SubscriptionPayment>
+    >(
+      await this.#req(
+        `/api/v1/app-deployments/${id}/upgrade${query}`,
+        "POST",
+        req,
+      ),
     );
     return data;
   }

--- a/src/components/payment-sources.ts
+++ b/src/components/payment-sources.ts
@@ -1,4 +1,5 @@
 import {
+  AppUpgradeRequest,
   LNVpsApi,
   SubscriptionPayment,
   VmInstance,
@@ -175,6 +176,37 @@ export function vmUpgradeSource(
       api.createVmUpgradePayment(vm.id, upgradeRequest, method, {
         paymentMethodId: opts.paymentMethodId,
       }),
+    pollPaid: async (paymentId) => {
+      const p = await api.getSubscriptionPayment(subscriptionId, paymentId);
+      return p.is_paid;
+    },
+  };
+}
+
+/**
+ * Pay for an app deployment resize (one-time, not a renewal).
+ *
+ * Like the VM upgrade, the charge is recorded as a payment on the deployment's
+ * subscription, so it polls through the subscription payment item endpoint.
+ */
+export function appUpgradeSource(
+  api: LNVpsApi,
+  deploymentId: number,
+  upgradeRequest: AppUpgradeRequest,
+  subscriptionId: number,
+): PaymentSource {
+  return {
+    createPayment: async (method, opts) =>
+      subscriptionToVmPayment(
+        await api.createAppUpgradePayment(
+          deploymentId,
+          upgradeRequest,
+          method,
+          {
+            paymentMethodId: opts.paymentMethodId,
+          },
+        ),
+      ),
     pollPaid: async (paymentId) => {
       const p = await api.getSubscriptionPayment(subscriptionId, paymentId);
       return p.is_paid;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -83,6 +83,9 @@
   "0t1qvq": {
     "defaultMessage": "Add Rule"
   },
+  "12+5NG": {
+    "defaultMessage": "Pro-rated upgrade"
+  },
   "13cluZ": {
     "defaultMessage": "Add SSH Key:"
   },
@@ -124,6 +127,9 @@
   },
   "2l2y5p": {
     "defaultMessage": "Create Order"
+  },
+  "2mZOHz": {
+    "defaultMessage": "Quote currency"
   },
   "36aVfS": {
     "defaultMessage": "Nostr DM"
@@ -268,6 +274,9 @@
   },
   "7Cdpiv": {
     "defaultMessage": "SSH Keys"
+  },
+  "7Iag/E": {
+    "defaultMessage": "Total due now"
   },
   "7NFfmz": {
     "defaultMessage": "Products"
@@ -449,14 +458,23 @@
   "Bzv1CO": {
     "defaultMessage": "Reactivate now"
   },
+  "CBHTGe": {
+    "defaultMessage": "Credit for time already paid"
+  },
   "CYP/Jx": {
     "defaultMessage": "Get help from the team"
   },
   "Cououe": {
     "defaultMessage": "Log in to deploy this app."
   },
+  "CwmTc6": {
+    "defaultMessage": "New renewal price"
+  },
   "D3idYv": {
     "defaultMessage": "Settings"
+  },
+  "D4ANpe": {
+    "defaultMessage": "{multiplier}× base app"
   },
   "D9mck8": {
     "defaultMessage": "Pay any amount, whenever — time is added pro-rata"
@@ -692,6 +710,9 @@
   "J+dIsA": {
     "defaultMessage": "Subscriptions"
   },
+  "J+pWCM": {
+    "defaultMessage": "New size"
+  },
   "JAJV1y": {
     "defaultMessage": "Assigned once running"
   },
@@ -736,6 +757,9 @@
   },
   "Kffxdm": {
     "defaultMessage": "Every plan includes one IPv4 and one IPv6 address and unmetered traffic. Prices include VAT; payment processing fees are excluded."
+  },
+  "KkHYsy": {
+    "defaultMessage": "Running at {current}× the base app. Resizing costs the difference for the rest of this period, then the new rate from the next renewal. The new size applies once the payment settles, and sizes can only go up."
   },
   "KuX7em": {
     "defaultMessage": "Active for {duration}"
@@ -848,6 +872,9 @@
   "PfSZy5": {
     "defaultMessage": "No order found"
   },
+  "PlcGQq": {
+    "defaultMessage": "Pay for this deployment before resizing it — an upgrade is charged pro-rata against the time left on the current period."
+  },
   "PucUfl": {
     "defaultMessage": "Select SSH Key:"
   },
@@ -940,6 +967,9 @@
   },
   "SB//YQ": {
     "defaultMessage": "Order summary"
+  },
+  "SMbDTG": {
+    "defaultMessage": "This deployment is already at the largest size we offer ({max}× the base app). Contact us if you need more."
   },
   "SQJto2": {
     "defaultMessage": "Sign in"
@@ -1183,6 +1213,9 @@
   },
   "acrOoz": {
     "defaultMessage": "Continue"
+  },
+  "agOXPD": {
+    "defaultMessage": "Size"
   },
   "alJZVR": {
     "defaultMessage": "Nostr account"
@@ -1658,6 +1691,9 @@
   "pgLgIU": {
     "defaultMessage": "Read the full update"
   },
+  "pgl1gp": {
+    "defaultMessage": "Resize to {size}× base"
+  },
   "pus6h6": {
     "defaultMessage": "Leave any time. Your code stops earning and can't be reused."
   },
@@ -1796,6 +1832,9 @@
   "ubXbwc": {
     "defaultMessage": "Default Policy"
   },
+  "uby/fm": {
+    "defaultMessage": "Get quote"
+  },
   "uqUeK9": {
     "defaultMessage": "Decrypt a message sent to you by support."
   },
@@ -1849,6 +1888,9 @@
   },
   "wLwJ9Q": {
     "defaultMessage": "Value of remaining time at old rate:"
+  },
+  "wa/t9c": {
+    "defaultMessage": "Pay and resize"
   },
   "waJLKW": {
     "defaultMessage": "Linked"

--- a/src/pages/account-app-deployment.tsx
+++ b/src/pages/account-app-deployment.tsx
@@ -1,8 +1,14 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { FormattedDate, FormattedMessage } from "react-intl";
-import { App, AppDeployment } from "../api";
+import {
+  App,
+  AppDeployment,
+  AppUpgradeQuote,
+  MAX_RESOURCE_MULTIPLIER,
+} from "../api";
 import useLogin from "../hooks/login";
+import usePaymentMethods from "../hooks/usePaymentMethods";
 import { ConfigInput } from "../components/deploy-app-form";
 import { parseAppConfig } from "../utils/app-compose";
 import Spinner from "../components/spinner";
@@ -10,7 +16,10 @@ import Seo from "../components/seo";
 import { PageHeader, SectionCard } from "../components/section";
 import { StatusPill } from "../components/billing";
 import { AsyncButton } from "../components/button";
-import { AppIcon, deploymentStatus } from "./account-apps";
+import { CostAmount } from "../components/cost";
+import PaymentFlow from "../components/payment-flow";
+import { appUpgradeSource } from "../components/payment-sources";
+import { AppIcon, AppResources, deploymentStatus } from "./account-apps";
 
 /** Edit a deployment's instance name and config field values. */
 function ConfigEditor({
@@ -136,6 +145,255 @@ function ConfigEditor({
           <span className="text-xs text-cyber-primary">
             <FormattedMessage defaultMessage="Saved. The app will restart shortly." />
           </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Payment methods the upgrade endpoint can charge interactively. Same set as
+ * the VM upgrade flow — NWC and LNURL have no interactive upgrade path.
+ */
+const UPGRADE_METHODS = ["lightning", "revolut", "paypal", "stripe"];
+
+/**
+ * Resize a deployment to a larger multiple of its app's base size: quote first,
+ * then pay. The API applies the resize only once that payment settles, so an
+ * abandoned upgrade leaves the deployment untouched.
+ */
+function UpgradeSection({
+  deployment,
+  onUpgraded,
+}: {
+  deployment: AppDeployment;
+  onUpgraded: () => void;
+}) {
+  const login = useLogin();
+  // Only used to pick the currency the quote comes back in; the method actually
+  // charged is chosen inside the payment flow.
+  const { data: paymentMethods } = usePaymentMethods();
+  // An API predating the resource multiplier omits the field; treat that as the
+  // base size rather than putting NaN in the controls.
+  const current = Math.max(1, deployment.resource_multiplier || 1);
+  const atMax = current >= MAX_RESOURCE_MULTIPLIER;
+
+  const [target, setTarget] = useState(
+    Math.min(current + 1, MAX_RESOURCE_MULTIPLIER),
+  );
+  const [quote, setQuote] = useState<AppUpgradeQuote>();
+  const [error, setError] = useState<string>();
+  const [selectedMethod, setSelectedMethod] = useState<string>("");
+  const [showPaymentFlow, setShowPaymentFlow] = useState(false);
+
+  const upgradeMethods = paymentMethods?.filter((m) =>
+    UPGRADE_METHODS.includes(m.name),
+  );
+
+  // Prefer a method settling in the user's currency so the quote is shown in
+  // it; otherwise the first available.
+  useEffect(() => {
+    if (selectedMethod || !upgradeMethods?.length) return;
+    const match = upgradeMethods.find((m) =>
+      (m.currencies as Array<string>).includes(login?.currency ?? ""),
+    );
+    setSelectedMethod((match ?? upgradeMethods[0]).name);
+  }, [selectedMethod, upgradeMethods, login?.currency]);
+
+  // The API prorates against the remaining paid period, so a deployment that
+  // has never been paid for has nothing to quote against. It answers with a 400
+  // saying so; say it up front instead of on submit.
+  if (
+    deployment.status === "pending" ||
+    deployment.subscription_id === undefined
+  ) {
+    return (
+      <p className="m-0 text-sm text-cyber-muted">
+        <FormattedMessage defaultMessage="Pay for this deployment before resizing it — an upgrade is charged pro-rata against the time left on the current period." />
+      </p>
+    );
+  }
+
+  if (atMax) {
+    return (
+      <p className="m-0 text-sm text-cyber-muted">
+        <FormattedMessage
+          defaultMessage="This deployment is already at the largest size we offer ({max}× the base app). Contact us if you need more."
+          values={{ max: MAX_RESOURCE_MULTIPLIER }}
+        />
+      </p>
+    );
+  }
+
+  if (showPaymentFlow && quote && login?.api) {
+    return (
+      <PaymentFlow
+        title={
+          <FormattedMessage
+            defaultMessage="Resize to {size}× base"
+            values={{ size: target }}
+          />
+        }
+        source={appUpgradeSource(
+          login.api,
+          deployment.id,
+          { resource_multiplier: target },
+          deployment.subscription_id,
+        )}
+        onPaymentComplete={() => {
+          setShowPaymentFlow(false);
+          setQuote(undefined);
+          onUpgraded();
+        }}
+        onCancel={() => setShowPaymentFlow(false)}
+      />
+    );
+  }
+
+  async function getQuote() {
+    if (!login?.api) return;
+    setError(undefined);
+    setQuote(undefined);
+    try {
+      setQuote(
+        await login.api.getAppUpgradeQuote(
+          deployment.id,
+          { resource_multiplier: target },
+          selectedMethod || undefined,
+        ),
+      );
+    } catch (e) {
+      if (e instanceof Error) setError(e.message);
+    }
+  }
+
+  // Sizes above the current one, up to the API's cap. Downgrades don't exist —
+  // volumes cannot shrink — so they are never offered.
+  const sizes: Array<number> = [];
+  for (let m = current + 1; m <= MAX_RESOURCE_MULTIPLIER; m++) sizes.push(m);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="m-0 text-sm text-cyber-muted">
+        <FormattedMessage
+          defaultMessage="Running at {current}× the base app. Resizing costs the difference for the rest of this period, then the new rate from the next renewal. The new size applies once the payment settles, and sizes can only go up."
+          values={{ current }}
+        />
+      </p>
+
+      <div className="flex flex-wrap gap-4">
+        <label className="flex flex-col gap-1">
+          <span className="text-[0.65rem] uppercase tracking-[0.2em] text-cyber-text">
+            <FormattedMessage defaultMessage="New size" />
+          </span>
+          <select
+            value={target}
+            onChange={(e) => {
+              setTarget(Number(e.target.value));
+              setQuote(undefined);
+            }}
+          >
+            {sizes.map((m) => (
+              <option key={m} value={m}>
+                {`${m}×`}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1">
+          <span className="text-[0.65rem] uppercase tracking-[0.2em] text-cyber-text">
+            <FormattedMessage defaultMessage="Quote currency" />
+          </span>
+          <select
+            value={selectedMethod}
+            onChange={(e) => {
+              setSelectedMethod(e.target.value);
+              setQuote(undefined);
+            }}
+          >
+            {upgradeMethods?.map((m) => (
+              <option key={m.name} value={m.name}>
+                {m.name.charAt(0).toUpperCase() + m.name.slice(1)}
+                {m.currencies.length > 0 && ` (${m.currencies.join(", ")})`}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {error && <b className="text-cyber-danger">{error}</b>}
+
+      {quote && (
+        <dl className="grid grid-cols-[max-content_1fr] gap-x-6 gap-y-2 border-t border-cyber-border pt-4 text-sm tabular-nums">
+          <dt className="text-cyber-muted">
+            <FormattedMessage defaultMessage="Credit for time already paid" />
+          </dt>
+          <dd className="m-0">
+            <CostAmount cost={quote.discount} converted={false} />
+          </dd>
+
+          <dt className="text-cyber-muted">
+            <FormattedMessage defaultMessage="Pro-rated upgrade" />
+          </dt>
+          <dd className="m-0">
+            <CostAmount cost={quote.cost_difference} converted={false} />
+          </dd>
+
+          <dt className="text-cyber-muted">
+            <FormattedMessage defaultMessage="VAT" />
+          </dt>
+          <dd className="m-0">
+            <CostAmount cost={quote.tax} converted={false} />
+          </dd>
+
+          {quote.processing_fee.amount > 0 && (
+            <>
+              <dt className="text-cyber-muted">
+                <FormattedMessage defaultMessage="Processing fee" />
+              </dt>
+              <dd className="m-0">
+                <CostAmount cost={quote.processing_fee} converted={false} />
+              </dd>
+            </>
+          )}
+
+          <dt className="text-cyber-text-bright">
+            <FormattedMessage defaultMessage="Total due now" />
+          </dt>
+          <dd className="m-0 text-cyber-text-bright">
+            <CostAmount
+              cost={{
+                currency: quote.cost_difference.currency,
+                amount:
+                  quote.cost_difference.amount +
+                  quote.tax.amount +
+                  quote.processing_fee.amount,
+              }}
+              converted={false}
+            />
+          </dd>
+
+          <dt className="text-cyber-muted">
+            <FormattedMessage defaultMessage="New renewal price" />
+          </dt>
+          <dd className="m-0">
+            <CostAmount cost={quote.new_renewal_cost} converted={false} />
+          </dd>
+        </dl>
+      )}
+
+      <div className="flex items-center gap-3">
+        <AsyncButton onClick={getQuote}>
+          <FormattedMessage defaultMessage="Get quote" />
+        </AsyncButton>
+        {quote && (
+          <AsyncButton
+            className="bg-cyber-primary/20 border-cyber-primary text-cyber-primary hover:bg-cyber-primary/30 hover:shadow-neon"
+            onClick={async () => setShowPaymentFlow(true)}
+          >
+            <FormattedMessage defaultMessage="Pay and resize" />
+          </AsyncButton>
         )}
       </div>
     </div>
@@ -288,6 +546,34 @@ export function AccountAppDeploymentPage() {
             </>
           )}
 
+          {/* The deployment's own figures, not the catalog app's: these already
+              have the resource multiplier applied. Skipped entirely against an
+              API old enough not to send them, rather than shown as an empty
+              row. */}
+          {(deployment.cpu_milli > 0 ||
+            deployment.memory_bytes > 0 ||
+            deployment.storage_bytes > 0) && (
+            <>
+              <dt className="text-cyber-muted">
+                <FormattedMessage defaultMessage="Size" />
+              </dt>
+              <dd className="m-0 flex flex-wrap items-center gap-x-3 text-cyber-text">
+                <AppResources
+                  app={deployment}
+                  className="font-mono text-xs text-cyber-text tabular-nums"
+                />
+                {deployment.resource_multiplier > 1 && (
+                  <span className="text-xs text-cyber-primary">
+                    <FormattedMessage
+                      defaultMessage="{multiplier}× base app"
+                      values={{ multiplier: deployment.resource_multiplier }}
+                    />
+                  </span>
+                )}
+              </dd>
+            </>
+          )}
+
           {deployment.status_message && (
             <>
               <dt className="text-cyber-muted">
@@ -341,6 +627,19 @@ export function AccountAppDeploymentPage() {
           />
         </SectionCard>
       )}
+
+      {/* Resize */}
+      <SectionCard title={<FormattedMessage defaultMessage="Size" />}>
+        <UpgradeSection
+          // Remount when the size changes so the selector re-bases off the new
+          // multiplier instead of offering a size that is no longer an upgrade.
+          key={`${deployment.id}-${deployment.resource_multiplier}`}
+          deployment={deployment}
+          onUpgraded={() =>
+            reload().catch((e) => e instanceof Error && setError(e.message))
+          }
+        />
+      </SectionCard>
 
       {/* Lifecycle */}
       <SectionCard title={<FormattedMessage defaultMessage="Manage" />}>

--- a/src/pages/account-apps.tsx
+++ b/src/pages/account-apps.tsx
@@ -107,12 +107,16 @@ function vcpu(milli: number): string | number {
   return Number.isInteger(cores) ? cores : cores.toFixed(cores < 1 ? 2 : 1);
 }
 
-/** Compact CPU · RAM · storage footprint line. */
+/**
+ * Compact CPU · RAM · storage footprint line. Takes the three figures rather
+ * than an `App` so a deployment's *effective* resources (already multiplied by
+ * the API) can use it too.
+ */
 export function AppResources({
   app,
   className,
 }: {
-  app: App;
+  app: Pick<App, "cpu_milli" | "memory_bytes" | "storage_bytes">;
   className?: string;
 }) {
   const parts: Array<ReactNode> = [];


### PR DESCRIPTION
Closes #36 (remaining scope after Alejandra's [re-scope](https://github.com/LNVPS/web/issues/36#issuecomment-5088868922)). From the `general` channel thread.

Items 2 and 3 of the issue — the `PATCH` client method, custom domains, `config` prefill — are already on `main` via `60a6d42` and are not touched here. This is items 1 and 4.

## 1. The four missing fields

`ApiAppDeployment` (`lnvps_api/src/api/apps.rs:151-190`) has serialised `resource_multiplier`, `cpu_milli`, `memory_bytes` and `storage_bytes` since api `b88f988`. `AppDeployment` declared none of them.

One correction to the issue's framing: the deployment page did not show *the base app's* size — it showed **no size at all**. `grep -rn "AppResources\|cpu_milli" src/pages/ src/components/` on `6920688` returns the catalog page (`app.tsx:184`, correctly the base app) and nothing on `account-app-deployment.tsx`. The customer-visible defect is the same either way: a deployment running at 4× had nothing on screen saying so.

Adds the four fields to the interface and a **Size** row built from the deployment's own figures, with a `{n}× base app` badge when the multiplier is above 1.

`AppResources` now takes `Pick<App, "cpu_milli" | "memory_bytes" | "storage_bytes">` instead of a whole `App`, so a deployment satisfies it structurally. The one existing call site (`app.tsx:184`) is unchanged.

## 2. The upgrade flow

`getAppUpgradeQuote` / `createAppUpgradePayment` in `src/api.ts`, `appUpgradeSource` in `payment-sources.ts`, and a resize section on the deployment page: pick a size, get a quote, pay.

The API's rules are enforced in the UI rather than discovered through 400s, which is what the issue asked for:

| API rule | Where | UI |
|---|---|---|
| `MAX_RESOURCE_MULTIPLIER = 16` | `apps.rs:627` | exported as `MAX_RESOURCE_MULTIPLIER`; the selector stops there |
| new multiplier must be **greater** than current | `apps.rs:643-647` | only `current+1 … 16` are offered; at 16 the section says so instead |
| unpaid deployment cannot be quoted | `apps.rs:664-668` | `status === "pending"` gets the explanation up front |

An **expired** deployment is the one case left to the server's message (`apps.rs:670-673`) — the deployment payload carries no expiry, so the page cannot know before asking. That message is already actionable ("Renew it before upgrading"), and it surfaces through the same `setError(e.message)` path as every other error on this page.

The charge lands on the deployment's own subscription, so `appUpgradeSource` polls `getSubscriptionPayment` exactly as `vmUpgradeSource` does — no new polling path, and none of the VM-only endpoint that #34 was about.

**Money.** Every amount stays in integer minor units and goes to `CostAmount` with `converted={false}`. The one sum — `cost_difference + tax + processing_fee` for "total due now" — is same-currency by construction, not by assumption: `apps.rs:715-721` builds `tax` and `processing_fee` with `CurrencyAmount::from_u64(currency, …)` where `currency` is taken from `cost_difference`. No second converter.

## Verified

At `e34f73e`, `git rev-parse HEAD` confirmed in the same shell as each run.

- `bunx tsc --noEmit` clean. `bun run build` clean. `bun run locale:extract` re-run on top of the edits reproduces `en.json` byte-for-byte.
- `bunx prettier --check` clean on `account-app-deployment.tsx`. `payment-sources.ts` and `api.ts` still fail prettier — they already did on `main`, with the identical six hunks before and after this branch; none is in code this PR adds.
- `bun run lint`: the only **error** is the pre-existing `@ts-ignore` at `server/prod.ts:13`. The files this PR touches produce no new warnings.
- SSR smoke test via `server/prod.ts` + curl on `/account/apps/deployments/1`: HTTP 200, `robots: noindex,nofollow` (correct for an account page), no render error in the log.

**Not verified, and it matters:** I have not seen this render. It is behind login, and I do not have an account — so the size row, the selector, the quote breakdown and the payment hand-off have not been exercised against a real deployment. `tsc` and the SSR smoke test prove it compiles and does not crash on import; they prove nothing about the quote numbers on screen. Worth a click-through on staging before this is trusted, particularly the quote breakdown against a BTC-priced app, where amounts are millisats.

## Locales

14 new strings. `bun run locale:extract` is in the commit. `locale:translate` needs an Ollama server (`package.json:19`) and `localhost:11434` refuses connections here, so the ten translated locales carry English for these until the next backlog run — the same state `6920688` cleared for the previous batch.

"VAT" and "Processing fee" reuse existing ids and keep their translations.
