### PR TITLE
fix(apps): make the resize quote's credit line visibly subtract

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1292,6 +1292,9 @@
   "d3wxHm": {
     "defaultMessage": "Loading history..."
   },
+  "dHfOPB": {
+    "defaultMessage": "Cost at new size for the rest of this period"
+  },
   "dHltrI": {
     "defaultMessage": "Billed every"
   },

--- a/src/pages/account-app-deployment.tsx
+++ b/src/pages/account-app-deployment.tsx
@@ -326,10 +326,28 @@ function UpgradeSection({
 
       {quote && (
         <dl className="grid grid-cols-[max-content_1fr] gap-x-6 gap-y-2 border-t border-cyber-border pt-4 text-sm tabular-nums">
+          {/* The API returns `cost_difference` already net of `discount`
+              (lnvps_api_common/src/pricing.rs:1466). Showing the gross first
+              makes the credit visibly subtract into it, the same derivation
+              the VM upgrade quote shows. */}
+          <dt className="text-cyber-muted">
+            <FormattedMessage defaultMessage="Cost at new size for the rest of this period" />
+          </dt>
+          <dd className="m-0">
+            <CostAmount
+              cost={{
+                currency: quote.cost_difference.currency,
+                amount: quote.cost_difference.amount + quote.discount.amount,
+              }}
+              converted={false}
+            />
+          </dd>
+
           <dt className="text-cyber-muted">
             <FormattedMessage defaultMessage="Credit for time already paid" />
           </dt>
           <dd className="m-0">
+            &minus;&nbsp;
             <CostAmount cost={quote.discount} converted={false} />
           </dd>
 


### PR DESCRIPTION
Follow-up to #40, found by rendering it rather than reading it.

## The defect

Against a real deployment and a real quote, the breakdown read as a credit that was quoted and then ignored:

| row | value |
|---|---|
| Credit for time already paid | 20,478 sats |
| Pro-rated upgrade | 10,231 sats |
| VAT | 2,353 sats |
| **Total due now** | **12,584 sats** |

Nothing on screen subtracts 20,478 from anything. A customer reasonably reads that as "you offered me a 20,478 sat credit and then charged me anyway".

The credit *is* applied — the API returns `cost_difference` already net of `discount`:

```rust
// lnvps_api_common/src/pricing.rs:1466
let upgrade = new_cost_until_expire.sub(discount)?;
```

Only the derivation was missing.

## The fix

Add the gross row above the credit and a minus sign on the credit, so the arithmetic reads off the page:

| row | value |
|---|---|
| Cost at new size for the rest of this period | 30,709 sats |
| Credit for time already paid | − 20,478 sats |
| Pro-rated upgrade | 10,231 sats |
| VAT | 2,353 sats |
| **Total due now** | **12,584 sats** |

This is the same three-line derivation `src/pages/vm-upgrade.tsx:336-366` already shows for VM upgrades; the app quote was the odd one out. One new English-only string, on the same pending `locale:translate` backlog as the 14 from #40.

## How it was verified

Alejandra's `GUIDES/LOCAL_RENDER_STACK.md` recipe, against `lnvps_api` on `:8000` with regtest Lightning — a seeded app deployment at 2×, an Irish VAT registration so the tax row is non-zero, and the app priced in USD while every payment method settles in BTC, so the quote exercises the millisats path.

End to end, not just the static page: quote → **Pay and resize** → `POST /app-deployments/4/upgrade` → real `lnbcrt` invoice for 12,607 sats → paid it on regtest → `appUpgradeSource` polled `/subscriptions/4/payments/{id}` → the page came back at **3× (0.75 vCPU · 768MB)**. No console errors at any step.

![resize quote with the derivation](https://apex-strata.communities.buzz.xyz/media/6ec1db0e1fc9d117785f2613999a350917113ba783de62ffd0b0bc3d02aba6f0.png)

![deployment after the paid resize](https://apex-strata.communities.buzz.xyz/media/1f2614f017413f3f5bb51df1157f27ac4a639abee48725cdc12cc26d7f68dc75.png)

`bunx tsc --noEmit` and `bun run build` clean at `357d153`.

Originating conversation: LNVPS `general`.
