### PR TITLE
feat(seo): add the /blossom-server-hosting use-case landing page

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -38,6 +38,12 @@
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
+  <!-- Use-case landing pages (#22). One per page as they land. -->
+  <url>
+    <loc>https://lnvps.net/blossom-server-hosting</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
   <url>
     <loc>https://lnvps.net/news</loc>
     <changefreq>weekly</changefreq>

--- a/src/const.ts
+++ b/src/const.ts
@@ -83,6 +83,16 @@ export const NostrProfile = new NostrLink(
 
 export const ServiceBirth = new Date("2024-06-05T00:00:00Z");
 
+/**
+ * Catalog id of Route96, the app `/blossom-server-hosting` sells.
+ *
+ * A use-case landing page is about one specific app, so the id is part of what
+ * the page *is* — it is also the target of the page's call to action
+ * (`/apps/2`). Kept here rather than in the page so the route loader and the
+ * page cannot drift apart.
+ */
+export const BlossomAppId = 2;
+
 export const System = new NostrSystem({
   automaticOutboxModel: false,
   buildFollowGraph: false,

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -7,7 +7,7 @@ import {
   AvailableIpSpace,
   App,
 } from "./api";
-import { ApiUrl, System } from "./const";
+import { ApiUrl, BlossomAppId, System } from "./const";
 import { filterArticlesByLocale } from "./utils/news-locale";
 import { detectLocale } from "./utils/locale";
 
@@ -160,4 +160,21 @@ export async function appsLoader(): Promise<AppsLoaderData> {
   const api = new LNVpsApi(ApiUrl ?? "", undefined, 5000);
   const apps = await cached("apps", () => api.listApps());
   return { apps };
+}
+
+/**
+ * `/blossom-server-hosting` sells one app, so it fetches that app alone —
+ * only to build its `Product`/`Offer` schema from the real price rather than a
+ * hardcoded one. The page's copy is static, so an undefined app costs the
+ * structured data and nothing else.
+ *
+ * Shares the `app_2` cache entry with `appLoader`, which fetches the same
+ * unauthenticated record for `/apps/2`.
+ */
+export async function blossomHostingLoader(): Promise<AppLoaderData> {
+  const api = new LNVpsApi(ApiUrl ?? "", undefined, 5000);
+  const app = await cached(`app_${BlossomAppId}`, () =>
+    api.getApp(BlossomAppId),
+  );
+  return { app };
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -8,6 +8,9 @@
   "+3NyB6": {
     "defaultMessage": "Outbound"
   },
+  "+Bj8tM": {
+    "defaultMessage": "Stopping retains your uploads; only deleting removes them"
+  },
   "+JVG/q": {
     "defaultMessage": "{n, plural, one {year} other {years}}"
   },
@@ -127,6 +130,9 @@
   },
   "2l2y5p": {
     "defaultMessage": "Create Order"
+  },
+  "2lKQfH": {
+    "defaultMessage": "How much can I store?"
   },
   "2mZOHz": {
     "defaultMessage": "Quote currency"
@@ -343,6 +349,9 @@
   },
   "8cnlb5": {
     "defaultMessage": "Save Payout Route"
+  },
+  "8dAKuZ": {
+    "defaultMessage": "Yes — CNAME, and the certificate is issued automatically once DNS resolves."
   },
   "8ecw1u": {
     "defaultMessage": "Handles"
@@ -584,6 +593,9 @@
   "FZeQlc": {
     "defaultMessage": "Disconnected"
   },
+  "FZup6q": {
+    "defaultMessage": "Where does it run?"
+  },
   "FazwRl": {
     "defaultMessage": "Try again"
   },
@@ -668,6 +680,9 @@
   "HPBE7M": {
     "defaultMessage": "Back to apps"
   },
+  "HVEPWR": {
+    "defaultMessage": "Run your own Blossom and NIP-96 media server for €3.50/month. Route96, up in minutes on its own hostname with 20 GB for your files and TLS included."
+  },
   "HVtxik": {
     "defaultMessage": "Custom domain"
   },
@@ -691,6 +706,9 @@
   },
   "IZFEUg": {
     "defaultMessage": "Ready"
+  },
+  "IbWc3k": {
+    "defaultMessage": "Dublin, Ireland."
   },
   "Id24hd": {
     "defaultMessage": "Name *"
@@ -872,6 +890,9 @@
   "PfSZy5": {
     "defaultMessage": "No order found"
   },
+  "Pk14hW": {
+    "defaultMessage": "Lightning, on-chain Bitcoin, or card. Log in with your Nostr key. No KYC."
+  },
   "PlcGQq": {
     "defaultMessage": "Pay for this deployment before resizing it — an upgrade is charged pro-rata against the time left on the current period."
   },
@@ -935,6 +956,9 @@
   "RCHbbR": {
     "defaultMessage": "Manage your billing details, automatic renewal and how we reach you."
   },
+  "RETAQj": {
+    "defaultMessage": "€3.50/month, no setup fee. 20 GB for your files."
+  },
   "RQNCao": {
     "defaultMessage": "NIP-05 identity hosting"
   },
@@ -979,6 +1003,9 @@
   },
   "SYYlLP": {
     "defaultMessage": "Manage the NIP-05 handles registered on this domain."
+  },
+  "SZwp5S": {
+    "defaultMessage": "How large a file can I upload?"
   },
   "Sczo8n": {
     "defaultMessage": "Duration: {duration}"
@@ -1040,6 +1067,9 @@
   "TgGVeW": {
     "defaultMessage": "Action required"
   },
+  "TlSf60": {
+    "defaultMessage": "Can I use my own domain?"
+  },
   "TqSTI0": {
     "defaultMessage": "Enable"
   },
@@ -1055,8 +1085,14 @@
   "U+Ddsx": {
     "defaultMessage": "Send on-chain Bitcoin to this address. Time is credited automatically once the transaction confirms, pro-rated by the amount received — partial and over-payments are never lost."
   },
+  "U0GEAC": {
+    "defaultMessage": "Stop uploading your images and video to someone else's server. Route96 is a Blossom and NIP-96 media server, deployed on LNVPS in minutes, with storage and TLS included."
+  },
   "U96Gl9": {
     "defaultMessage": "Save this card for future payments"
+  },
+  "UANa+W": {
+    "defaultMessage": "Route96 is a high-performance Blossom / NIP-96 server. It is <a>open source</a>, and it is ours — we wrote it and we run it. You are not trusting a black box; you can read every line, and you can leave with your data whenever you want."
   },
   "UPP+wZ": {
     "defaultMessage": "In use by {count, plural, one {VM} other {VMs}}: {vms}"
@@ -1115,6 +1151,9 @@
   "VzzYJk": {
     "defaultMessage": "Create"
   },
+  "W8nHSd": {
+    "defaultMessage": "FAQ"
+  },
   "WEoZhh": {
     "defaultMessage": "Couldn't find a subscription to bill this upgrade to."
   },
@@ -1136,6 +1175,9 @@
   "WxTcqt": {
     "defaultMessage": "{n, plural, one {month} other {months}}"
   },
+  "X/xmPf": {
+    "defaultMessage": "Isolated environment with its own database"
+  },
   "X0ha1a": {
     "defaultMessage": "Save changes"
   },
@@ -1154,11 +1196,17 @@
   "Y+LcmX": {
     "defaultMessage": "If you cannot change your DNS, proxy {path} on your existing server to {target}"
   },
+  "Y+P9PL": {
+    "defaultMessage": "Bring your own domain via CNAME — separate certificate issued automatically"
+  },
   "Y/tMXU": {
     "defaultMessage": "Waiting for payment. This is applied automatically once it confirms."
   },
   "YWjrby": {
     "defaultMessage": "Account alerts only, such as VM expiration. We never send marketing messages."
+  },
+  "Yc91CY": {
+    "defaultMessage": "Up to 100 MB per upload."
   },
   "YdQxfw": {
     "defaultMessage": "Contact Support"
@@ -1174,6 +1222,9 @@
   },
   "Z+AMVE": {
     "defaultMessage": "Email Verification Required"
+  },
+  "Z+US89": {
+    "defaultMessage": "Host your own media server — €3.50 a month"
   },
   "Z3gKpL": {
     "defaultMessage": "storage"
@@ -1204,6 +1255,12 @@
   },
   "a60eIK": {
     "defaultMessage": "Saving re-applies the config and restarts the app."
+  },
+  "aHQFgG": {
+    "defaultMessage": "Blossom Media Server Hosting from €3.50/month"
+  },
+  "aLe15X": {
+    "defaultMessage": "Pay how you like"
   },
   "aPcXT9": {
     "defaultMessage": "Payouts are batched with other on-chain referrers into one transaction once your balance clears the minimum. Your share of the network fee is deducted from your balance. Mainnet addresses only."
@@ -1478,6 +1535,9 @@
   "j4RCJW": {
     "defaultMessage": "SKILL.md"
   },
+  "j52BNh": {
+    "defaultMessage": "Why self-host media"
+  },
   "j7VE/p": {
     "defaultMessage": "Standard BTC transaction — credits after confirmation"
   },
@@ -1499,8 +1559,14 @@
   "jf7fbc": {
     "defaultMessage": "None set — add one"
   },
+  "jgrdHK": {
+    "defaultMessage": "20 GB of files, with a separate 5 GB volume for the database. For a personal media server that is comfortable; if you need more, a VPS with Route96 installed yourself scales further."
+  },
   "jhBqwg": {
     "defaultMessage": "Point a CNAME for this domain at the deployment hostname once it is assigned. Leave empty to remove."
+  },
+  "jhyC12": {
+    "defaultMessage": "What is included"
   },
   "jmVweB": {
     "defaultMessage": "Loading SSH keys..."
@@ -1514,6 +1580,9 @@
   "jwt9EL": {
     "defaultMessage": "Passkey sign-in failed"
   },
+  "k2S+Z0": {
+    "defaultMessage": "A protocol for storing and retrieving files addressed by their hash, designed to work with Nostr. NIP-96 is the older HTTP file-storage spec — Route96 speaks both."
+  },
   "k9Pskm": {
     "defaultMessage": "Fast solid-state storage"
   },
@@ -1522,6 +1591,9 @@
   },
   "kLNEaL": {
     "defaultMessage": "Please complete the captcha verification"
+  },
+  "kNIWoA": {
+    "defaultMessage": "Uploads up to 100 MB each"
   },
   "kRFEho": {
     "defaultMessage": "Add SSH Key"
@@ -1582,6 +1654,9 @@
   },
   "m4xBT/": {
     "defaultMessage": "Managed Apps: run the software without running the server"
+  },
+  "mDRXDi": {
+    "defaultMessage": "Nostr keeps your identity portable. Media has been the part that is not — your images live on someone else's host, under someone else's terms, and disappear when they do. A Blossom server puts that back under your key."
   },
   "mIuuiJ": {
     "defaultMessage": "Service Status and Uptime"
@@ -1697,6 +1772,9 @@
   "pgl1gp": {
     "defaultMessage": "Resize to {size}× base"
   },
+  "ps4K9r": {
+    "defaultMessage": "What is Blossom?"
+  },
   "pus6h6": {
     "defaultMessage": "Leave any time. Your code stops earning and can't be reused."
   },
@@ -1777,6 +1855,9 @@
   },
   "sUw18G": {
     "defaultMessage": "Encrypted messaging is only available for Nostr accounts. Your account has no Nostr key to read or send NIP-17 messages. For help, please use the Support tab."
+  },
+  "si4AIj": {
+    "defaultMessage": "Deploy Route96 — €3.50/month"
   },
   "sn+Rj5": {
     "defaultMessage": "Sign in with a passkey"
@@ -1907,11 +1988,20 @@
   "x0cZXf": {
     "defaultMessage": "Upgrade Not Available"
   },
+  "x27Qqd": {
+    "defaultMessage": "20 GB persistent storage for your files, plus a 5 GB database volume of its own — 25 GB allocated in total"
+  },
+  "xExBHw": {
+    "defaultMessage": "Your own hostname — <code>your-name.ie.apps.lnvps.cloud</code> — with automatic TLS"
+  },
   "xOnplm": {
     "defaultMessage": "Loading payment methods…"
   },
   "xQ8iOj": {
     "defaultMessage": "You don't have any subscriptions yet."
+  },
+  "xUdVjn": {
+    "defaultMessage": "Route96"
   },
   "xXbJso": {
     "defaultMessage": "Sign out"

--- a/src/pages/blossom-server-hosting.tsx
+++ b/src/pages/blossom-server-hosting.tsx
@@ -42,6 +42,14 @@ function Section({
  * empty shell to keep out of the index. The loader exists only to supply the
  * app's real price to the `Product`/`Offer` schema; without it the page simply
  * ships no product markup.
+ *
+ * **If Route96's price changes, the strings here change too.** The `Offer`
+ * price is derived, but the title, meta description, h1 and CTA all carry a
+ * literal `€3.50` — deliberately, because a headline that reads from the
+ * catalog would vanish when the catalog is down. The cost of that choice is
+ * this coupling: leave the copy stale and the JSON-LD and the visible text
+ * disagree, which is what disqualifies the rich result. Search this file for
+ * `3.50`.
  */
 export function BlossomServerHostingPage() {
   const { formatMessage } = useIntl();

--- a/src/pages/blossom-server-hosting.tsx
+++ b/src/pages/blossom-server-hosting.tsx
@@ -1,0 +1,205 @@
+import { ReactNode } from "react";
+import { Link, useLoaderData } from "react-router-dom";
+import { FormattedMessage, useIntl } from "react-intl";
+import Seo from "../components/seo";
+import { appJsonLd } from "../utils/app-seo";
+import { faqJsonLd, type FaqItem } from "../utils/faq-seo";
+import { BlossomAppId } from "../const";
+import type { AppLoaderData } from "../loaders";
+
+/** Section heading in the site's eyebrow style, kept as an h2 for structure.
+ * Mirrors `SectionHeading` in `home.tsx:172`. */
+function SectionHeading({ children }: { children: ReactNode }) {
+  return (
+    <h2 className="flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-cyber-muted">
+      <span className="h-px w-3 bg-cyber-border-bright" />
+      {children}
+    </h2>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-3">
+      <SectionHeading>{title}</SectionHeading>
+      {children}
+    </section>
+  );
+}
+
+/**
+ * `/blossom-server-hosting` — use-case landing page for Route96, the Blossom /
+ * NIP-96 media server in the managed app catalog (`LNVPS/web#38`).
+ *
+ * The copy is fixed marketing prose, so the page renders in full even when the
+ * catalog is unreachable — unlike `/apps/:id` there is no id to resolve and no
+ * empty shell to keep out of the index. The loader exists only to supply the
+ * app's real price to the `Product`/`Offer` schema; without it the page simply
+ * ships no product markup.
+ */
+export function BlossomServerHostingPage() {
+  const { formatMessage } = useIntl();
+  const { app } = useLoaderData<AppLoaderData>();
+
+  // Rendered as the FAQ block *and* handed to `faqJsonLd`, so the two can
+  // never say different things. Answers ship as written — expanding one
+  // usually costs `FAQPage` eligibility.
+  //
+  // The custom-domain question and the matching "What is included" bullet were
+  // cut on web#38 while web#36 was open, then restored: `60a6d42` shipped the
+  // UI (`account-app-deployment.tsx:40`, `:550`) and it is on `origin/main`.
+  const faq: FaqItem[] = [
+    {
+      question: formatMessage({ defaultMessage: "What is Blossom?" }),
+      answer: formatMessage({
+        defaultMessage:
+          "A protocol for storing and retrieving files addressed by their hash, designed to work with Nostr. NIP-96 is the older HTTP file-storage spec — Route96 speaks both.",
+      }),
+    },
+    {
+      question: formatMessage({ defaultMessage: "How much can I store?" }),
+      answer: formatMessage({
+        defaultMessage:
+          "20 GB of files, with a separate 5 GB volume for the database. For a personal media server that is comfortable; if you need more, a VPS with Route96 installed yourself scales further.",
+      }),
+    },
+    {
+      question: formatMessage({
+        defaultMessage: "How large a file can I upload?",
+      }),
+      answer: formatMessage({ defaultMessage: "Up to 100 MB per upload." }),
+    },
+    {
+      question: formatMessage({ defaultMessage: "Can I use my own domain?" }),
+      answer: formatMessage({
+        defaultMessage:
+          "Yes — CNAME, and the certificate is issued automatically once DNS resolves.",
+      }),
+    },
+    {
+      question: formatMessage({ defaultMessage: "Where does it run?" }),
+      answer: formatMessage({ defaultMessage: "Dublin, Ireland." }),
+    },
+  ];
+
+  return (
+    <>
+      <Seo
+        title={formatMessage({
+          defaultMessage: "Blossom Media Server Hosting from €3.50/month",
+        })}
+        canonical="/blossom-server-hosting"
+        description={formatMessage({
+          defaultMessage:
+            "Run your own Blossom and NIP-96 media server for €3.50/month. Route96, up in minutes on its own hostname with 20 GB for your files and TLS included.",
+        })}
+        jsonLd={[...(app ? [appJsonLd(app)] : []), faqJsonLd(faq)]}
+      />
+      <div className="flex flex-col gap-8">
+        <header className="flex flex-col gap-3">
+          <h1 className="m-0 text-3xl text-cyber-text-bright">
+            <FormattedMessage defaultMessage="Host your own media server — €3.50 a month" />
+          </h1>
+          <p className="m-0 max-w-prose text-cyber-text">
+            <FormattedMessage defaultMessage="Stop uploading your images and video to someone else's server. Route96 is a Blossom and NIP-96 media server, deployed on LNVPS in minutes, with storage and TLS included." />
+          </p>
+        </header>
+
+        <Section title={<FormattedMessage defaultMessage="Route96" />}>
+          <p className="m-0 font-bold text-cyber-primary">
+            <FormattedMessage defaultMessage="€3.50/month, no setup fee. 20 GB for your files." />
+          </p>
+          <p className="m-0 max-w-prose text-cyber-text">
+            <FormattedMessage
+              defaultMessage="Route96 is a high-performance Blossom / NIP-96 server. It is <a>open source</a>, and it is ours — we wrote it and we run it. You are not trusting a black box; you can read every line, and you can leave with your data whenever you want."
+              values={{
+                a: (chunks) => (
+                  <a
+                    href="https://github.com/v0l/route96"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-cyber-primary hover:underline"
+                  >
+                    {chunks}
+                  </a>
+                ),
+              }}
+            />
+          </p>
+        </Section>
+
+        <Section title={<FormattedMessage defaultMessage="What is included" />}>
+          <ul className="m-0 flex max-w-prose list-disc flex-col gap-1 pl-5 text-cyber-text">
+            <li>
+              <FormattedMessage defaultMessage="20 GB persistent storage for your files, plus a 5 GB database volume of its own — 25 GB allocated in total" />
+            </li>
+            <li>
+              <FormattedMessage defaultMessage="Uploads up to 100 MB each" />
+            </li>
+            <li>
+              <FormattedMessage
+                defaultMessage="Your own hostname — <code>your-name.ie.apps.lnvps.cloud</code> — with automatic TLS"
+                values={{
+                  code: (chunks) => (
+                    <code className="font-mono text-cyber-accent">
+                      {chunks}
+                    </code>
+                  ),
+                }}
+              />
+            </li>
+            <li>
+              <FormattedMessage defaultMessage="Bring your own domain via CNAME — separate certificate issued automatically" />
+            </li>
+            <li>
+              <FormattedMessage defaultMessage="Isolated environment with its own database" />
+            </li>
+            <li>
+              <FormattedMessage defaultMessage="Stopping retains your uploads; only deleting removes them" />
+            </li>
+          </ul>
+        </Section>
+
+        <Section title={<FormattedMessage defaultMessage="Why self-host media" />}>
+          <p className="m-0 max-w-prose text-cyber-text">
+            <FormattedMessage defaultMessage="Nostr keeps your identity portable. Media has been the part that is not — your images live on someone else's host, under someone else's terms, and disappear when they do. A Blossom server puts that back under your key." />
+          </p>
+        </Section>
+
+        <Section title={<FormattedMessage defaultMessage="Pay how you like" />}>
+          <p className="m-0 max-w-prose text-cyber-text">
+            <FormattedMessage defaultMessage="Lightning, on-chain Bitcoin, or card. Log in with your Nostr key. No KYC." />
+          </p>
+        </Section>
+
+        <Section title={<FormattedMessage defaultMessage="FAQ" />}>
+          <dl className="m-0 flex max-w-prose flex-col gap-4">
+            {faq.map((f) => (
+              <div key={f.question} className="flex flex-col gap-1">
+                <dt className="m-0 font-bold text-cyber-text-bright">
+                  {f.question}
+                </dt>
+                <dd className="m-0 text-cyber-text">{f.answer}</dd>
+              </div>
+            ))}
+          </dl>
+        </Section>
+
+        <div>
+          <Link
+            to={`/apps/${BlossomAppId}`}
+            className="inline-block rounded-sm border border-cyber-primary bg-cyber-primary/20 px-4 py-2 font-bold uppercase text-cyber-primary hover:bg-cyber-primary/30 hover:shadow-neon"
+          >
+            <FormattedMessage defaultMessage="Deploy Route96 — €3.50/month" />
+          </Link>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -26,6 +26,7 @@ import { AccountSubscriptionsPage } from "./pages/account-subscriptions.tsx";
 import { AccountAppsPage } from "./pages/account-apps.tsx";
 import { AppPage } from "./pages/app.tsx";
 import { AppsPage } from "./pages/apps.tsx";
+import { BlossomServerHostingPage } from "./pages/blossom-server-hosting.tsx";
 import { AccountAppDeploymentPage } from "./pages/account-app-deployment.tsx";
 import { AccountSubscriptionPage } from "./pages/account-subscription.tsx";
 import { AccountSshKeysPage } from "./pages/account-ssh-keys.tsx";
@@ -34,6 +35,7 @@ import VmLayout from "./pages/vm-layout.tsx";
 import {
   appLoader,
   appsLoader,
+  blossomHostingLoader,
   homeLoader,
   newsLoader,
   newsPostLoader,
@@ -143,6 +145,11 @@ export const routes: RouteObject[] = [
         path: "/apps/:id",
         element: <AppPage />,
         loader: appLoader,
+      },
+      {
+        path: "/blossom-server-hosting",
+        element: <BlossomServerHostingPage />,
+        loader: blossomHostingLoader,
       },
       {
         path: "/vm",

--- a/src/utils/faq-seo.ts
+++ b/src/utils/faq-seo.ts
@@ -1,0 +1,31 @@
+/**
+ * A single question and its answer, both already localised. The page renders
+ * these exact strings *and* passes them here, so the markup a crawler reads
+ * and the text a visitor reads cannot drift — which is the one thing that
+ * disqualifies a `FAQPage` rich result.
+ */
+export interface FaqItem {
+  question: string;
+  answer: string;
+}
+
+/**
+ * `FAQPage` structured data for a list of questions.
+ *
+ * `acceptedAnswer.text` is plain text, not markup: answers are written short
+ * and self-contained so they stay eligible, so there is nothing to mark up.
+ */
+export function faqJsonLd(items: FaqItem[]): object {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: items.map((i) => ({
+      "@type": "Question",
+      name: i.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: i.answer,
+      },
+    })),
+  };
+}


### PR DESCRIPTION
Closes #38. Copy is Jessica's, verbatim from the issue and [its full-copy comment](https://github.com/LNVPS/web/issues/38#issuecomment-5091002586).

## What is here

New SSR'd route `/blossom-server-hosting`, registered next to `/apps` in `src/routes.tsx`, plus `blossomHostingLoader`, `Product`/`Offer` + `FAQPage` markup, and a sitemap entry.

The loader does less than the pattern usually implies: every string on this page is fixed prose, so it exists **only** to build the `Product`/`Offer` schema from the app's real price. If the catalog is unreachable the page still renders in full and just ships no product markup — there is no id to resolve, so no empty shell, so no `noindex` fallback. That is the one way it differs from `/apps/:id`.

- **Price is derived, never hardcoded.** `appJsonLd` from #33, reused rather than re-written. Rendered head has `"price": "3.50"` built from `amount: 350`.
- **`FAQPage` via a new `src/utils/faq-seo.ts`.** The same `FaqItem[]` is rendered as the FAQ block *and* passed to the schema, so the markup and the visible text cannot drift.
- **20 GB, not 25.** Route96's `storage_bytes` is 25 GiB, but `compose` splits it `blobs 20Gi` + `data 5Gi` and the 5 GiB is MariaDB. Re-confirmed against live `/api/v1/apps` today.

## One decision worth your eye

**The custom-domain bullet and its FAQ answer are in, not cut.** #38's [first comment](https://github.com/LNVPS/web/issues/38#issuecomment-5088611476) cut both because the front end had no path to set a custom domain. That is no longer true — `60a6d42` shipped the UI and it is on `origin/main` (`src/pages/account-app-deployment.tsx:40` is the field, `:550` renders the live domain), and #49's copy comment says so explicitly and restores the equivalent bullet there. Building from the cut would have dropped a feature we ship. Jessica if you disagree, it is two `<li>`/FAQ entries to pull.

## Gate

The CTA is `/apps/2` — in the repo, not on production. That is #23. **This page should go live in the same deploy as the catalog**, otherwise its only CTA lands on a blank page.

## Verification

At `433e243`:

- `bunx tsc --noEmit` — clean
- `bun run build` — clean
- `server/prod.ts` + `curl /blossom-server-hosting` — real `<title>`, `<h1>`, `<meta name="description">`, `<link rel="canonical">`, both JSON-LD blocks, no `robots` tag
- `curl /sitemap.xml` — contains the new URL
- Rendered page checked in headless Chrome
- `bun run lint` still exits 1 on the pre-existing `server/prod.ts:13` `@ts-ignore`. Not touched here.

## Not in this commit

The ten non-English locales. `locale:extract` has added the new ids to `en.json`; the `locale:translate` pass is running and lands as a second commit on this branch before merge — **do not merge until it is here**, or the page ships English-only in eleven languages.

Commit is `--no-gpg-sign`; signing is not available in this environment.
