### PR TITLE
fix(a11y): raise secondary-text contrast to WCAG AA in both themes

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -18,7 +18,11 @@
   --color-cyber-danger: #ff0040;
   --color-cyber-danger-dim: oklch(0.55 0.25 15 / 0.4);
   --color-cyber-success: oklch(0.8 0.3 142);
-  --color-cyber-muted: #4a5568;
+  /* Secondary text. Must clear WCAG AA (4.5:1) against every surface it can
+     land on — cyber-darker #050505, cyber-dark #0a0a0a, cyber-panel #0d1117
+     and cyber-panel-light #161b22. The old #4a5568 was 2.30–2.71:1 on those,
+     i.e. failing everywhere. Worst case now is 5.67:1 on cyber-panel-light. */
+  --color-cyber-muted: #8695a8;
   --color-cyber-text: #b8c4d0;
   --color-cyber-text-bright: #e2e8f0;
 
@@ -113,7 +117,10 @@
   --color-cyber-danger: #dc2626;
   --color-cyber-danger-dim: oklch(0.5 0.2 25 / 0.27);
   --color-cyber-success: #16a34a;
-  --color-cyber-muted: #9ca3af;
+  /* Same rule as the dark token: the light surfaces run from #f3f4f6 down to
+     cyber-panel-light #d1d5db, and #9ca3af was 1.72–2.31:1 on them. Worst case
+     now is 5.13:1, still lighter than cyber-text #374151 so the hierarchy holds. */
+  --color-cyber-muted: #4b5563;
   --color-cyber-text: #374151;
   --color-cyber-text-bright: #111827;
 


### PR DESCRIPTION
Raises `--color-cyber-muted` in both themes so secondary text clears WCAG AA (4.5:1).

Reported by @v0l in the `lnvps` channel — "the text contrast on dark theme is bad, it's like gray on black", narrowed to `/apps`.

## What was wrong

`--color-cyber-muted` is the site's secondary-text token (276 uses across `src/`). It failed AA against **every** surface it is painted on, in both themes:

| theme | token | on `cyber-darker` | on `cyber-panel` | on `cyber-panel-light` |
|---|---|---|---|---|
| dark | `#4a5568` | 2.71:1 | 2.51:1 | 2.30:1 |
| light | `#9ca3af` | 2.31:1 | 1.97:1 | 1.72:1 |

All three backgrounds are real pairings — `text-cyber-muted` sits on `bg-cyber-panel-light` at `src/components/billing.tsx:39`, `src/components/os-image-icon.tsx:69` and `src/components/vps-instance.tsx:159`.

On `/apps` in dark theme this token was the *entire* problem: of nine distinct text styles on the page, exactly three failed AA and all three were `text-cyber-muted` — the intro paragraph (2.71:1), the per-app price (2.71:1) and the app card descriptions (2.51:1). Nothing else on the page failed.

## The change

New values clear AA against the darkest and lightest surface each theme can put them on, and stay a clear step away from `--color-cyber-text` so the primary/secondary hierarchy still reads:

| theme | was | now | worst case | vs `cyber-text` |
|---|---|---|---|---|
| dark | `#4a5568` | `#8695a8` | 5.67:1 | 6.68:1 vs 11.50:1 |
| light | `#9ca3af` | `#4b5563` | 5.13:1 | 5.86:1 vs 7.00:1 |

One-token change, no markup touched.

## Verification

Measured with computed styles in headless Chrome against the production build (`server/prod.ts`), resolving each text node's effective colour over its nearest opaque ancestor background:

- `/apps` dark theme: **9 text styles, 0 AA failures** (was 3 failures).
- `bunx tsc --noEmit` clean, `bun run build` exit 0, at `2ac69ea`.
- Rendered page checked visually — secondary copy is legible and still reads as secondary.

## Two things this does *not* fix

**1. Light theme still has 7 AA failures on `/apps`, from a different pair of tokens.** `--color-cyber-primary` (`#16a34a`) and `--color-cyber-accent` (`#0891b2`) sit at 2.24–3.35:1 on the light backgrounds. Those are brand colours on headings and links, so darkening them is a design call rather than a bug fix — not doing it unilaterally. Happy to take it as a follow-up if @v0l and Jessica want it.

**2. `text-*` utilities on `h1`, `h2`, `h3` and `a` are dead site-wide.** The element rules at `src/index.css:165-195` are unlayered, and unlayered CSS outranks everything in `@layer utilities`, so they beat every Tailwind utility. Verified in the browser:

```
h1.text-3xl          → font-size 22.5px  (--text-2xl, not --text-3xl)
h1.text-cyber-text-bright → oklch(0.8 0.3 142)  (cyber-primary, not #e2e8f0)
a.text-cyber-primary → rgb(0, 255, 242)  (cyber-accent, not cyber-primary)
```

So every `<h1 className="text-3xl text-cyber-text-bright">` on the site — including the three landing pages — renders green at `2xl`. It looks intentional because green headings *are* the site's look, but the classes are lying. Wrapping those rules in `@layer base` would fix it and would change heading colours across the whole site, so it needs its own PR and a look from Jessica. Filing separately.

---

Originating channel: `lnvps` (`f5894ea9-44c7-56fb-bd9b-6e3e671e4bc1`)

Commit is unsigned — GPG signing is unavailable in this environment (no TTY for pinentry).
