### PR TITLE
fix(i18n): take the price out of the translatable strings on /blossom-server-hosting

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -308,6 +308,9 @@
   "7tOz+m": {
     "defaultMessage": "Pay now"
   },
+  "7v5vj0": {
+    "defaultMessage": "Host your own media server — {price} a month"
+  },
   "7wbySo": {
     "defaultMessage": "Send us a message directly and the team will get back to you."
   },
@@ -680,9 +683,6 @@
   "HPBE7M": {
     "defaultMessage": "Back to apps"
   },
-  "HVEPWR": {
-    "defaultMessage": "Run your own Blossom and NIP-96 media server for €3.50/month. Route96, up in minutes on its own hostname with 20 GB for your files and TLS included."
-  },
   "HVtxik": {
     "defaultMessage": "Custom domain"
   },
@@ -796,6 +796,9 @@
   },
   "LHX6Oo": {
     "defaultMessage": "Expires {exp}"
+  },
+  "LKipQw": {
+    "defaultMessage": "{price}/month, no setup fee. 20 GB for your files."
   },
   "LR754a": {
     "defaultMessage": "Renews at"
@@ -955,9 +958,6 @@
   },
   "RCHbbR": {
     "defaultMessage": "Manage your billing details, automatic renewal and how we reach you."
-  },
-  "RETAQj": {
-    "defaultMessage": "€3.50/month, no setup fee. 20 GB for your files."
   },
   "RQNCao": {
     "defaultMessage": "NIP-05 identity hosting"
@@ -1223,9 +1223,6 @@
   "Z+AMVE": {
     "defaultMessage": "Email Verification Required"
   },
-  "Z+US89": {
-    "defaultMessage": "Host your own media server — €3.50 a month"
-  },
   "Z3gKpL": {
     "defaultMessage": "storage"
   },
@@ -1255,9 +1252,6 @@
   },
   "a60eIK": {
     "defaultMessage": "Saving re-applies the config and restarts the app."
-  },
-  "aHQFgG": {
-    "defaultMessage": "Blossom Media Server Hosting from €3.50/month"
   },
   "aLe15X": {
     "defaultMessage": "Pay how you like"
@@ -1580,6 +1574,9 @@
   "jwt9EL": {
     "defaultMessage": "Passkey sign-in failed"
   },
+  "jzU8se": {
+    "defaultMessage": "Deploy Route96 — {price}/month"
+  },
   "k2S+Z0": {
     "defaultMessage": "A protocol for storing and retrieving files addressed by their hash, designed to work with Nostr. NIP-96 is the older HTTP file-storage spec — Route96 speaks both."
   },
@@ -1763,6 +1760,9 @@
   "p5LNtB": {
     "defaultMessage": "Not set"
   },
+  "pJmk+U": {
+    "defaultMessage": "Run your own Blossom and NIP-96 media server for {price}/month. Route96, up in minutes on its own hostname with 20 GB for your files and TLS included."
+  },
   "pYX859": {
     "defaultMessage": "Deleting"
   },
@@ -1856,8 +1856,8 @@
   "sUw18G": {
     "defaultMessage": "Encrypted messaging is only available for Nostr accounts. Your account has no Nostr key to read or send NIP-17 messages. For help, please use the Support tab."
   },
-  "si4AIj": {
-    "defaultMessage": "Deploy Route96 — €3.50/month"
+  "sehISV": {
+    "defaultMessage": "Blossom Media Server Hosting from {price}/month"
   },
   "sn+Rj5": {
     "defaultMessage": "Sign in with a passkey"

--- a/src/pages/blossom-server-hosting.tsx
+++ b/src/pages/blossom-server-hosting.tsx
@@ -2,10 +2,27 @@ import { ReactNode } from "react";
 import { Link, useLoaderData } from "react-router-dom";
 import { FormattedMessage, useIntl } from "react-intl";
 import Seo from "../components/seo";
+import { CostAmount } from "../components/cost";
 import { appJsonLd } from "../utils/app-seo";
 import { faqJsonLd, type FaqItem } from "../utils/faq-seo";
+import { formatPriceText } from "../utils/currency";
 import { BlossomAppId } from "../const";
 import type { AppLoaderData } from "../loaders";
+
+/**
+ * Route96's price as this page claims it, for the render where the catalog is
+ * unreachable.
+ *
+ * The page has to keep its headline when the API is down (web#38), so the
+ * price cannot be *only* derived — but it must not sit inside a translatable
+ * string either, or eleven locale files end up carrying a number that only
+ * `src/api.ts` should decide. So it lives here, once, in minor units, and is
+ * painted by the same code that paints the live figure. `350` is €3.50.
+ *
+ * If Route96's catalog price changes this is the only line to change; the
+ * copy, the `Offer` markup and the `<title>` all follow from it.
+ */
+const FALLBACK_PRICE = { currency: "EUR", amount: 350 };
 
 /** Section heading in the site's eyebrow style, kept as an h2 for structure.
  * Mirrors `SectionHeading` in `home.tsx:172`. */
@@ -43,17 +60,27 @@ function Section({
  * app's real price to the `Product`/`Offer` schema; without it the page simply
  * ships no product markup.
  *
- * **If Route96's price changes, the strings here change too.** The `Offer`
- * price is derived, but the title, meta description, h1 and CTA all carry a
- * literal `€3.50` — deliberately, because a headline that reads from the
- * catalog would vanish when the catalog is down. The cost of that choice is
- * this coupling: leave the copy stale and the JSON-LD and the visible text
- * disagree, which is what disqualifies the rich result. Search this file for
- * `3.50`.
+ * Every price on the page — title, meta description, h1, the Route96 line and
+ * the CTA — is a `{price}` placeholder fed from the catalog, falling back to
+ * `FALLBACK_PRICE` when the loader has nothing. So the copy, the `Offer`
+ * markup and the `<title>` cannot disagree, and no locale file carries the
+ * number.
  */
 export function BlossomServerHostingPage() {
-  const { formatMessage } = useIntl();
+  const intl = useIntl();
+  const { formatMessage } = intl;
   const { app } = useLoaderData<AppLoaderData>();
+
+  // Ex-VAT and unconverted, matching the `Offer`'s `valueAddedTaxIncluded:
+  // false` and what a crawler is served. `interval_type` is left off on
+  // purpose: the period is part of the sentence around the placeholder, so
+  // "/month" and "a month" stay translatable instead of being appended by
+  // `CostAmount` in a fixed position.
+  const price = app
+    ? { currency: app.currency, amount: app.amount }
+    : FALLBACK_PRICE;
+  const priceText = formatPriceText(intl, price);
+  const priceNode = <CostAmount cost={price} converted={false} />;
 
   // Rendered as the FAQ block *and* handed to `faqJsonLd`, so the two can
   // never say different things. Answers ship as written — expanding one
@@ -99,20 +126,29 @@ export function BlossomServerHostingPage() {
   return (
     <>
       <Seo
-        title={formatMessage({
-          defaultMessage: "Blossom Media Server Hosting from €3.50/month",
-        })}
+        title={formatMessage(
+          {
+            defaultMessage: "Blossom Media Server Hosting from {price}/month",
+          },
+          { price: priceText },
+        )}
         canonical="/blossom-server-hosting"
-        description={formatMessage({
-          defaultMessage:
-            "Run your own Blossom and NIP-96 media server for €3.50/month. Route96, up in minutes on its own hostname with 20 GB for your files and TLS included.",
-        })}
+        description={formatMessage(
+          {
+            defaultMessage:
+              "Run your own Blossom and NIP-96 media server for {price}/month. Route96, up in minutes on its own hostname with 20 GB for your files and TLS included.",
+          },
+          { price: priceText },
+        )}
         jsonLd={[...(app ? [appJsonLd(app)] : []), faqJsonLd(faq)]}
       />
       <div className="flex flex-col gap-8">
         <header className="flex flex-col gap-3">
           <h1 className="m-0 text-3xl text-cyber-text-bright">
-            <FormattedMessage defaultMessage="Host your own media server — €3.50 a month" />
+            <FormattedMessage
+              defaultMessage="Host your own media server — {price} a month"
+              values={{ price: priceNode }}
+            />
           </h1>
           <p className="m-0 max-w-prose text-cyber-text">
             <FormattedMessage defaultMessage="Stop uploading your images and video to someone else's server. Route96 is a Blossom and NIP-96 media server, deployed on LNVPS in minutes, with storage and TLS included." />
@@ -121,7 +157,10 @@ export function BlossomServerHostingPage() {
 
         <Section title={<FormattedMessage defaultMessage="Route96" />}>
           <p className="m-0 font-bold text-cyber-primary">
-            <FormattedMessage defaultMessage="€3.50/month, no setup fee. 20 GB for your files." />
+            <FormattedMessage
+              defaultMessage="{price}/month, no setup fee. 20 GB for your files."
+              values={{ price: priceNode }}
+            />
           </p>
           <p className="m-0 max-w-prose text-cyber-text">
             <FormattedMessage
@@ -174,7 +213,9 @@ export function BlossomServerHostingPage() {
           </ul>
         </Section>
 
-        <Section title={<FormattedMessage defaultMessage="Why self-host media" />}>
+        <Section
+          title={<FormattedMessage defaultMessage="Why self-host media" />}
+        >
           <p className="m-0 max-w-prose text-cyber-text">
             <FormattedMessage defaultMessage="Nostr keeps your identity portable. Media has been the part that is not — your images live on someone else's host, under someone else's terms, and disappear when they do. A Blossom server puts that back under your key." />
           </p>
@@ -204,7 +245,10 @@ export function BlossomServerHostingPage() {
             to={`/apps/${BlossomAppId}`}
             className="inline-block rounded-sm border border-cyber-primary bg-cyber-primary/20 px-4 py-2 font-bold uppercase text-cyber-primary hover:bg-cyber-primary/30 hover:shadow-neon"
           >
-            <FormattedMessage defaultMessage="Deploy Route96 — €3.50/month" />
+            <FormattedMessage
+              defaultMessage="Deploy Route96 — {price}/month"
+              values={{ price: priceNode }}
+            />
           </Link>
         </div>
       </div>

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -1,3 +1,4 @@
+import type { IntlShape } from "react-intl";
 import { ExchangeRates } from "../api";
 
 /**
@@ -7,6 +8,37 @@ import { ExchangeRates } from "../api";
  */
 export function smallestUnitScale(currency: string): number {
   return currency === "BTC" ? 100_000_000_000 : 100;
+}
+
+/**
+ * The figure `CostAmount` renders, as a plain string.
+ *
+ * `CostAmount` (`src/components/cost.tsx:96`) is the only thing that should
+ * paint a price, and everything that renders JSX keeps using it. This exists
+ * for the two slots that cannot take an element — `Seo`'s `title` and
+ * `description`, which are `formatMessage` strings — so a page can put its
+ * price in a `{price}` placeholder there instead of writing the number into
+ * the translatable copy.
+ *
+ * Deliberately not the same thing as `CostLabel`: no currency conversion and
+ * no VAT gross-up. A `<title>` is rendered once on the server for whoever asks
+ * for the URL, so it has no display currency and no account to read a tax
+ * setting from, and the `Offer` markup alongside it asserts
+ * `valueAddedTaxIncluded: false`.
+ */
+export function formatPriceText(
+  intl: IntlShape,
+  cost: { currency: string; amount: number },
+): string {
+  if (cost.currency === "BTC") {
+    // Mirrors `CostAmount`: millisats floored to sats, no currency style.
+    return `${intl.formatNumber(Math.floor(cost.amount / 1000))} sats`;
+  }
+  return intl.formatNumber(cost.amount / smallestUnitScale(cost.currency), {
+    style: "currency",
+    currency: cost.currency,
+    trailingZeroDisplay: "stripIfInteger",
+  });
 }
 
 /** A currency's rate relative to the snapshot base (the base itself is 1). */


### PR DESCRIPTION
Takes the literal price out of five translatable strings on `/blossom-server-hosting`, and adds the string-slot formatter the other two landing pages need for the same fix.

Raised by @v0l in the `lnvps` channel — *"why are you embedding prices in the strings, come on, that's never ok"*. Correct, and worse than the JSON-LD/copy drift Jessica flagged separately: a number inside a `defaultMessage` **cannot be localised at all**. It is frozen as `€3.50` in all eleven locales, so German renders `€3.50` where it should read `3,50 €` — and the running `locale:translate` pass was already copying the figure into ten files.

## What changed

Five `defaultMessage`s carried `€3.50`: the `<title>`, the meta description, the h1, the Route96 price line and the CTA. All five are now `{price}` placeholders.

`/apps` already had the right shape for this — `apps.tsx:83` renders `From {price}.` with a `<CostAmount>` in `values`. This is the same thing applied to the landing page, so there is no new pattern here.

`Seo`'s `title` and `description` are `formatMessage` strings and cannot take an element, so `formatPriceText` (`src/utils/currency.ts`) renders the figure `CostAmount` renders, as text, off the same `smallestUnitScale`. It is deliberately **not** `CostLabel`: no currency conversion and no VAT gross-up. A `<title>` is server-rendered for whoever asks for the URL — there is no display currency and no account to read a tax setting from — and the `Offer` markup beside it already asserts `valueAddedTaxIncluded: false`.

## Jessica's constraint still holds

Her note on #38 was that the page must not stop rendering its own headline when the catalog is down, so the price cannot be *only* derived. It isn't: the value comes from the loader and falls back to `FALLBACK_PRICE`, a single constant in minor units at the top of the file (`350` is €3.50). The fallback is a number in code, not a string in ten locale files — which is the part that was wrong.

`/month` and `a month` stay outside the placeholder, so the billing period stays translatable instead of being appended by `CostAmount` in a fixed position.

## Verification

`server/prod.ts` + curl:

| case | result |
|---|---|
| live catalog | title, description, h1, price line and CTA all render `€3.50` — byte-identical to before; `Offer` still `"price":"3.50"` |
| `VITE_API_URL` at a dead port | title and h1 still render `€3.50` from the fallback; the `Product`/`Offer` block correctly absent |
| `Accept-Language: de` / `fr` | `3,50 €` in the `<title>` |
| `Accept-Language: ja` | `€3.50` |

Before this change every locale got `€3.50`.

`bunx tsc --noEmit` clean, `bun run build` exit 0, at `50a185a`. `src/locales/en.json` re-extracted — five message ids replaced.

## Two follow-ups this creates

1. **The `locale:translate` pass in flight is translating the five old ids.** They no longer exist. `ollama_intl` is incremental by default (`--force` is what re-does existing keys), so a re-run after this merges will pick up just the five new ones cheaply — but the pass currently running does need re-running.
2. **web#52 needs the identical fix** for `/nostr-relay-hosting` (`€2`, four strings) and `/lightning-node-vps` (`€2`, one). It imports `formatPriceText` from here, so **merge this before #52**. I'll push that commit to #52 once this lands rather than stacking two open PRs on each other.

---

Originating channel: `lnvps` (`f5894ea9-44c7-56fb-bd9b-6e3e671e4bc1`)

Commit is unsigned — GPG signing is unavailable in this environment (no TTY for pinentry).
