### PR TITLE
fix(apps): lift BytesSize into a callable helper; leave /blossom-server-hosting's storage copy written

### DIFF
--- a/src/components/bytes.tsx
+++ b/src/components/bytes.tsx
@@ -1,24 +1,11 @@
 import { useIntl } from "react-intl";
-import { GiB, KiB, MiB, TiB } from "../const";
+import { formatBytesText } from "../utils/bytes";
 
 interface BytesSizeProps {
   value: number;
   precision?: number;
 }
 export default function BytesSize(props: BytesSizeProps) {
-  const { formatNumber } = useIntl();
-  const fmt = (n: number) =>
-    formatNumber(n, { maximumFractionDigits: props.precision ?? 0 });
-
-  if (props.value >= TiB) {
-    return fmt(props.value / TiB) + "TB";
-  } else if (props.value >= GiB) {
-    return fmt(props.value / GiB) + "GB";
-  } else if (props.value >= MiB) {
-    return fmt(props.value / MiB) + "MB";
-  } else if (props.value >= KiB) {
-    return fmt(props.value / KiB) + "KB";
-  } else {
-    return fmt(props.value) + "B";
-  }
+  const intl = useIntl();
+  return formatBytesText(intl, props.value, props.precision);
 }

--- a/src/const.ts
+++ b/src/const.ts
@@ -97,15 +97,19 @@ export const BlossomAppId = 2;
  * Catalog `name` slugs of the four relay implementations
  * `/nostr-relay-hosting` sells, in the order the page lists them.
  *
- * `GET /api/v1/apps` returns a flat list with no category or tag field, so a
- * page that sells a subset of the catalog has to name that subset somewhere.
- * This is that list, and it is the only thing about those apps written into
- * the front end: display name, price, storage and the `/apps/:id` link all
- * come from the catalog row. Slugs rather than the numeric ids this used to
- * hold — a slug is checkable against the API response by eye, an id is not.
+ * A page that sells a subset of the catalog has to name that subset
+ * somewhere. This is that list, and it is the only thing about those apps
+ * written into the front end: display name, price, storage and the
+ * `/apps/:id` link all come from the catalog row. Slugs rather than the
+ * numeric ids this used to hold — a slug is checkable against the API
+ * response by eye, an id is not.
  *
- * If the API ever grows app categories, this becomes a category filter and
- * nothing else on the page has to change.
+ * This used to say the API has no category or tag field. It has both as of
+ * `lnvps_db/migrations/20260727090000_app_tags.sql`, which seeds a `relay`
+ * tag: `App` in `src/api.ts:620` does not model either field yet, so nothing
+ * here can filter on them today. Whether that tag picks out exactly these
+ * four on the live catalog is `LNVPS/api#258` — if it does, this list becomes
+ * a tag filter and nothing else on the page has to change.
  */
 export const RelayAppSlugs = [
   "strfry",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -14,9 +14,6 @@
   "+EHk4e": {
     "defaultMessage": "Yes. It is your machine — install what you like."
   },
-  "+H6Rvj": {
-    "defaultMessage": "Run your own Blossom and NIP-96 media server for {price}/month. Route96, up in minutes on its own hostname with persistent storage and TLS included."
-  },
   "+JVG/q": {
     "defaultMessage": "{n, plural, one {year} other {years}}"
   },
@@ -1676,6 +1673,9 @@
   "jf7fbc": {
     "defaultMessage": "None set — add one"
   },
+  "jgrdHK": {
+    "defaultMessage": "20 GB of files, with a separate 5 GB volume for the database. For a personal media server that is comfortable; if you need more, a VPS with Route96 installed yourself scales further."
+  },
   "jhBqwg": {
     "defaultMessage": "Point a CNAME for this domain at the deployment hostname once it is assigned. Leave empty to remove."
   },
@@ -1900,6 +1900,9 @@
   },
   "p5LNtB": {
     "defaultMessage": "Not set"
+  },
+  "pJmk+U": {
+    "defaultMessage": "Run your own Blossom and NIP-96 media server for {price}/month. Route96, up in minutes on its own hostname with 20 GB for your files and TLS included."
   },
   "pYX859": {
     "defaultMessage": "Deleting"
@@ -2138,9 +2141,6 @@
   "wLwJ9Q": {
     "defaultMessage": "Value of remaining time at old rate:"
   },
-  "wVT7Mm": {
-    "defaultMessage": "{storage} of persistent storage, shared between your files and the database"
-  },
   "wa/t9c": {
     "defaultMessage": "Pay and resize"
   },
@@ -2156,6 +2156,9 @@
   "x0cZXf": {
     "defaultMessage": "Upgrade Not Available"
   },
+  "x27Qqd": {
+    "defaultMessage": "20 GB persistent storage for your files, plus a 5 GB database volume of its own — 25 GB allocated in total"
+  },
   "xExBHw": {
     "defaultMessage": "Your own hostname — <code>your-name.ie.apps.lnvps.cloud</code> — with automatic TLS"
   },
@@ -2170,9 +2173,6 @@
   },
   "xXbJso": {
     "defaultMessage": "Sign out"
-  },
-  "xbKCvF": {
-    "defaultMessage": "{storage} in total, shared between your files and the database. For a personal media server that is comfortable; if you need more, a VPS with Route96 installed yourself scales further."
   },
   "xf2LGD": {
     "defaultMessage": "auto-renews {date}"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -14,6 +14,9 @@
   "+EHk4e": {
     "defaultMessage": "Yes. It is your machine — install what you like."
   },
+  "+H6Rvj": {
+    "defaultMessage": "Run your own Blossom and NIP-96 media server for {price}/month. Route96, up in minutes on its own hostname with persistent storage and TLS included."
+  },
   "+JVG/q": {
     "defaultMessage": "{n, plural, one {year} other {years}}"
   },
@@ -860,9 +863,6 @@
   "LHX6Oo": {
     "defaultMessage": "Expires {exp}"
   },
-  "LKipQw": {
-    "defaultMessage": "{price}/month, no setup fee. 20 GB for your files."
-  },
   "LR754a": {
     "defaultMessage": "Renews at"
   },
@@ -1144,6 +1144,9 @@
   },
   "TaUfJI": {
     "defaultMessage": "Show LNURL"
+  },
+  "Tb1zdK": {
+    "defaultMessage": "{price}/month, no setup fee."
   },
   "Tbo377": {
     "defaultMessage": "Billing"
@@ -1673,9 +1676,6 @@
   "jf7fbc": {
     "defaultMessage": "None set — add one"
   },
-  "jgrdHK": {
-    "defaultMessage": "20 GB of files, with a separate 5 GB volume for the database. For a personal media server that is comfortable; if you need more, a VPS with Route96 installed yourself scales further."
-  },
   "jhBqwg": {
     "defaultMessage": "Point a CNAME for this domain at the deployment hostname once it is assigned. Leave empty to remove."
   },
@@ -1900,9 +1900,6 @@
   },
   "p5LNtB": {
     "defaultMessage": "Not set"
-  },
-  "pJmk+U": {
-    "defaultMessage": "Run your own Blossom and NIP-96 media server for {price}/month. Route96, up in minutes on its own hostname with 20 GB for your files and TLS included."
   },
   "pYX859": {
     "defaultMessage": "Deleting"
@@ -2141,6 +2138,9 @@
   "wLwJ9Q": {
     "defaultMessage": "Value of remaining time at old rate:"
   },
+  "wVT7Mm": {
+    "defaultMessage": "{storage} of persistent storage, shared between your files and the database"
+  },
   "wa/t9c": {
     "defaultMessage": "Pay and resize"
   },
@@ -2156,9 +2156,6 @@
   "x0cZXf": {
     "defaultMessage": "Upgrade Not Available"
   },
-  "x27Qqd": {
-    "defaultMessage": "20 GB persistent storage for your files, plus a 5 GB database volume of its own — 25 GB allocated in total"
-  },
   "xExBHw": {
     "defaultMessage": "Your own hostname — <code>your-name.ie.apps.lnvps.cloud</code> — with automatic TLS"
   },
@@ -2173,6 +2170,9 @@
   },
   "xXbJso": {
     "defaultMessage": "Sign out"
+  },
+  "xbKCvF": {
+    "defaultMessage": "{storage} in total, shared between your files and the database. For a personal media server that is comfortable; if you need more, a VPS with Route96 installed yourself scales further."
   },
   "xf2LGD": {
     "defaultMessage": "auto-renews {date}"

--- a/src/pages/blossom-server-hosting.tsx
+++ b/src/pages/blossom-server-hosting.tsx
@@ -6,6 +6,7 @@ import { CostAmount } from "../components/cost";
 import { appJsonLd } from "../utils/app-seo";
 import { faqJsonLd, type FaqItem } from "../utils/faq-seo";
 import { formatPriceText } from "../utils/currency";
+import { formatBytesText } from "../utils/bytes";
 import { BlossomAppId } from "../const";
 import type { AppLoaderData } from "../loaders";
 
@@ -65,6 +66,13 @@ function Section({
  * `FALLBACK_PRICE` when the loader has nothing. So the copy, the `Offer`
  * markup and the `<title>` cannot disagree, and no locale file carries the
  * number.
+ *
+ * Storage is the same rule with no fallback (`LNVPS/web#60`): the total comes
+ * off `app.storage_bytes` or the page does not claim a size. The 20GB files /
+ * 5GB database split it used to print is not something the client can derive —
+ * the volumes are `blobs` and `data` on two services and nothing in the API
+ * says which is which — so the page states the total and `LNVPS/api#260` is
+ * what would let it state the breakdown.
  */
 export function BlossomServerHostingPage() {
   const intl = useIntl();
@@ -82,6 +90,12 @@ export function BlossomServerHostingPage() {
   const priceText = formatPriceText(intl, price);
   const priceNode = <CostAmount cost={price} converted={false} />;
 
+  // The catalog's figure or nothing — unlike the price there is no fallback
+  // constant, because a storage size written into the front end is product
+  // data the client has no business holding. With the API unreachable the two
+  // slots below simply do not render; the rest of the page is unaffected.
+  const storage = app ? formatBytesText(intl, app.storage_bytes) : undefined;
+
   // Rendered as the FAQ block *and* handed to `faqJsonLd`, so the two can
   // never say different things. Answers ship as written — expanding one
   // usually costs `FAQPage` eligibility.
@@ -97,13 +111,26 @@ export function BlossomServerHostingPage() {
           "A protocol for storing and retrieving files addressed by their hash, designed to work with Nostr. NIP-96 is the older HTTP file-storage spec — Route96 speaks both.",
       }),
     },
-    {
-      question: formatMessage({ defaultMessage: "How much can I store?" }),
-      answer: formatMessage({
-        defaultMessage:
-          "20 GB of files, with a separate 5 GB volume for the database. For a personal media server that is comfortable; if you need more, a VPS with Route96 installed yourself scales further.",
-      }),
-    },
+    // The answer *is* `storage_bytes`, so with the catalog unreachable there
+    // is nothing honest to put in it and the question is not asked. Dropping
+    // the item drops it from the rendered `<dl>` and from `faqJsonLd`
+    // together, which is why the two share this array.
+    ...(storage
+      ? [
+          {
+            question: formatMessage({
+              defaultMessage: "How much can I store?",
+            }),
+            answer: formatMessage(
+              {
+                defaultMessage:
+                  "{storage} in total, shared between your files and the database. For a personal media server that is comfortable; if you need more, a VPS with Route96 installed yourself scales further.",
+              },
+              { storage },
+            ),
+          },
+        ]
+      : []),
     {
       question: formatMessage({
         defaultMessage: "How large a file can I upload?",
@@ -136,7 +163,7 @@ export function BlossomServerHostingPage() {
         description={formatMessage(
           {
             defaultMessage:
-              "Run your own Blossom and NIP-96 media server for {price}/month. Route96, up in minutes on its own hostname with 20 GB for your files and TLS included.",
+              "Run your own Blossom and NIP-96 media server for {price}/month. Route96, up in minutes on its own hostname with persistent storage and TLS included.",
           },
           { price: priceText },
         )}
@@ -156,9 +183,16 @@ export function BlossomServerHostingPage() {
         </header>
 
         <Section title={<FormattedMessage defaultMessage="Route96" />}>
+          {/*
+            The size that used to close this line is now in the "What is
+            included" bullet below, where it can be conditional on the catalog
+            having answered. A bold headline sentence cannot be — it would
+            need a second `defaultMessage` in eleven locales for the render
+            where the API is down.
+          */}
           <p className="m-0 font-bold text-cyber-primary">
             <FormattedMessage
-              defaultMessage="{price}/month, no setup fee. 20 GB for your files."
+              defaultMessage="{price}/month, no setup fee."
               values={{ price: priceNode }}
             />
           </p>
@@ -183,9 +217,14 @@ export function BlossomServerHostingPage() {
 
         <Section title={<FormattedMessage defaultMessage="What is included" />}>
           <ul className="m-0 flex max-w-prose list-disc flex-col gap-1 pl-5 text-cyber-text">
-            <li>
-              <FormattedMessage defaultMessage="20 GB persistent storage for your files, plus a 5 GB database volume of its own — 25 GB allocated in total" />
-            </li>
+            {storage ? (
+              <li>
+                <FormattedMessage
+                  defaultMessage="{storage} of persistent storage, shared between your files and the database"
+                  values={{ storage }}
+                />
+              </li>
+            ) : null}
             <li>
               <FormattedMessage defaultMessage="Uploads up to 100 MB each" />
             </li>

--- a/src/pages/blossom-server-hosting.tsx
+++ b/src/pages/blossom-server-hosting.tsx
@@ -6,7 +6,6 @@ import { CostAmount } from "../components/cost";
 import { appJsonLd } from "../utils/app-seo";
 import { faqJsonLd, type FaqItem } from "../utils/faq-seo";
 import { formatPriceText } from "../utils/currency";
-import { formatBytesText } from "../utils/bytes";
 import { BlossomAppId } from "../const";
 import type { AppLoaderData } from "../loaders";
 
@@ -67,12 +66,14 @@ function Section({
  * markup and the `<title>` cannot disagree, and no locale file carries the
  * number.
  *
- * Storage is the same rule with no fallback (`LNVPS/web#60`): the total comes
- * off `app.storage_bytes` or the page does not claim a size. The 20GB files /
- * 5GB database split it used to print is not something the client can derive —
- * the volumes are `blobs` and `data` on two services and nothing in the API
- * says which is which — so the page states the total and `LNVPS/api#260` is
- * what would let it state the breakdown.
+ * Storage is deliberately NOT that shape, and this is the one place on the site
+ * where a written figure beats a derived one (`LNVPS/web#60`). `storage_bytes`
+ * is 25 GiB — the sum of two fixed volumes, `blobs` 20Gi for uploads and `data`
+ * 5Gi for the database — and nothing in the API says which is which. Rendering
+ * the sum tells a buyer they have 25 GB for files when they have 20; rendering
+ * the sum next to a written split is the one version that can contradict itself
+ * the day the app is resized. So both slots stay literal until `LNVPS/api#260`
+ * gives volumes a label, and web#60 stays open on it.
  */
 export function BlossomServerHostingPage() {
   const intl = useIntl();
@@ -90,12 +91,6 @@ export function BlossomServerHostingPage() {
   const priceText = formatPriceText(intl, price);
   const priceNode = <CostAmount cost={price} converted={false} />;
 
-  // The catalog's figure or nothing — unlike the price there is no fallback
-  // constant, because a storage size written into the front end is product
-  // data the client has no business holding. With the API unreachable the two
-  // slots below simply do not render; the rest of the page is unaffected.
-  const storage = app ? formatBytesText(intl, app.storage_bytes) : undefined;
-
   // Rendered as the FAQ block *and* handed to `faqJsonLd`, so the two can
   // never say different things. Answers ship as written — expanding one
   // usually costs `FAQPage` eligibility.
@@ -111,26 +106,16 @@ export function BlossomServerHostingPage() {
           "A protocol for storing and retrieving files addressed by their hash, designed to work with Nostr. NIP-96 is the older HTTP file-storage spec — Route96 speaks both.",
       }),
     },
-    // The answer *is* `storage_bytes`, so with the catalog unreachable there
-    // is nothing honest to put in it and the question is not asked. Dropping
-    // the item drops it from the rendered `<dl>` and from `faqJsonLd`
-    // together, which is why the two share this array.
-    ...(storage
-      ? [
-          {
-            question: formatMessage({
-              defaultMessage: "How much can I store?",
-            }),
-            answer: formatMessage(
-              {
-                defaultMessage:
-                  "{storage} in total, shared between your files and the database. For a personal media server that is comfortable; if you need more, a VPS with Route96 installed yourself scales further.",
-              },
-              { storage },
-            ),
-          },
-        ]
-      : []),
+    // Written, not derived, and unconditional with it: `storage_bytes` only
+    // knows the 25 GiB total, and "25GB" here reads as 25 GB of room for
+    // uploads when the answer is 20. See the note on the component above.
+    {
+      question: formatMessage({ defaultMessage: "How much can I store?" }),
+      answer: formatMessage({
+        defaultMessage:
+          "20 GB of files, with a separate 5 GB volume for the database. For a personal media server that is comfortable; if you need more, a VPS with Route96 installed yourself scales further.",
+      }),
+    },
     {
       question: formatMessage({
         defaultMessage: "How large a file can I upload?",
@@ -163,7 +148,7 @@ export function BlossomServerHostingPage() {
         description={formatMessage(
           {
             defaultMessage:
-              "Run your own Blossom and NIP-96 media server for {price}/month. Route96, up in minutes on its own hostname with persistent storage and TLS included.",
+              "Run your own Blossom and NIP-96 media server for {price}/month. Route96, up in minutes on its own hostname with 20 GB for your files and TLS included.",
           },
           { price: priceText },
         )}
@@ -184,11 +169,9 @@ export function BlossomServerHostingPage() {
 
         <Section title={<FormattedMessage defaultMessage="Route96" />}>
           {/*
-            The size that used to close this line is now in the "What is
-            included" bullet below, where it can be conditional on the catalog
-            having answered. A bold headline sentence cannot be — it would
-            need a second `defaultMessage` in eleven locales for the render
-            where the API is down.
+            No size on this line: the "What is included" bullet three lines
+            down states it, and a figure written in two slots is a figure that
+            can be corrected in one of them.
           */}
           <p className="m-0 font-bold text-cyber-primary">
             <FormattedMessage
@@ -217,14 +200,9 @@ export function BlossomServerHostingPage() {
 
         <Section title={<FormattedMessage defaultMessage="What is included" />}>
           <ul className="m-0 flex max-w-prose list-disc flex-col gap-1 pl-5 text-cyber-text">
-            {storage ? (
-              <li>
-                <FormattedMessage
-                  defaultMessage="{storage} of persistent storage, shared between your files and the database"
-                  values={{ storage }}
-                />
-              </li>
-            ) : null}
+            <li>
+              <FormattedMessage defaultMessage="20 GB persistent storage for your files, plus a 5 GB database volume of its own — 25 GB allocated in total" />
+            </li>
             <li>
               <FormattedMessage defaultMessage="Uploads up to 100 MB each" />
             </li>

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -1,0 +1,37 @@
+import type { IntlShape } from "react-intl";
+import { GiB, KiB, MiB, TiB } from "../const";
+
+/**
+ * The figure `BytesSize` renders, as a plain string.
+ *
+ * `BytesSize` (`src/components/bytes.tsx:8`) is the only thing that should
+ * paint a byte count, and everything that renders JSX keeps using it. This
+ * exists for the slots that cannot take an element — `Seo`'s `description`,
+ * FAQ answers that are also handed to `faqJsonLd` — so a page can put a size
+ * in a `{storage}` placeholder there instead of writing the number into the
+ * translatable copy.
+ *
+ * Binary units labelled decimally, exactly as `BytesSize` has always done it:
+ * a 20Gi volume reads "20GB", which is what the app catalog and the compose
+ * both call it.
+ */
+export function formatBytesText(
+  intl: IntlShape,
+  value: number,
+  precision = 0,
+): string {
+  const fmt = (n: number) =>
+    intl.formatNumber(n, { maximumFractionDigits: precision });
+
+  if (value >= TiB) {
+    return fmt(value / TiB) + "TB";
+  } else if (value >= GiB) {
+    return fmt(value / GiB) + "GB";
+  } else if (value >= MiB) {
+    return fmt(value / MiB) + "MB";
+  } else if (value >= KiB) {
+    return fmt(value / KiB) + "KB";
+  } else {
+    return fmt(value) + "B";
+  }
+}


### PR DESCRIPTION
**Rewritten after review.** The first commit (`7dab8ca`) derived the storage figure on `/blossom-server-hosting` from `app.storage_bytes`; `2f51801` reverts that copy on Jessica's and Alejandra's ruling and keeps the parts api#260 will need. Net effect on the page: one editorial line and comments.

## Why the derived version was wrong

`storage_bytes` is `26843545600` (25 GiB) — but that is two fixed volumes, `blobs 20Gi` (`/app/data`, uploads) plus `data 5Gi` (`/var/lib/mysql`), not a pool. Rendering the sum tells a buyer they have 25 GB for files when the answer is 20 — the overstatement #60 exists to prevent.

And the obvious middle — derived total beside a written split — is the one option that can contradict itself: it renders "30GB in total, 20 GB for your files, plus a 5 GB database volume" the day the app is resized.

So this is the narrow case where the **written figure is more accurate than the derivable one**. LNVPS/api#260 (per-volume `label`) is what changes that. #60 stays open on it, plus the 100 MB upload cap, which is `max_upload_bytes` inside the route96 service's config file and not an API field at all.

## What this PR actually lands

- **`src/utils/bytes.ts`** — `formatBytesText`, `BytesSize`'s arithmetic in a form the slots that take a string not an element can call (`Seo`'s `description`, FAQ answers that also feed `faqJsonLd`). Mirrors `formatPriceText`. `BytesSize` now calls it; **its only caller today is `BytesSize` itself** — it is here because api#260 wants it.
- **`src/const.ts` comment** — it said `GET /api/v1/apps` "returns a flat list with no category or tag field". It has both as of `lnvps_db/migrations/20260727090000_app_tags.sql`, which also seeds a `relay` tag over exactly the four slugs `RelayAppSlugs` names. `App` (`src/api.ts:620`) models neither field, so nothing changes today — the comment now points at LNVPS/api#258. Comment only.
- **One copy change**, Jessica's call: the Route96 price line drops to `{price}/month, no setup fee.` The size belongs in the "What is included" bullet, and a figure written in two slots is a figure that gets corrected in one of them.
- **Reverted to `main` byte for byte**, with their ten translations intact: the "What is included" bullet, the "How much can I store?" FAQ answer, and the meta description.

## Verification at `2f51801`

`server/prod.ts` against a stub catalog and against a dead port:

- Live: bullet reads "20 GB persistent storage… 25 GB allocated in total", FAQ answer matches `main`, `Offer` still `"price":"3.50"`, no derived `25GB` anywhere in the served HTML.
- API down: identical copy, `<title>`/`<h1>` on the fallback price, `Product` block absent as before.
- `/apps/2` prints 25GB / 20GB / 5GB / 512MB through the lifted `BytesSize` — same arithmetic as before the extraction.

`bunx tsc --noEmit` clean, `bun run build` exit 0. `src/locales/en.json` re-extracted: one message id replaced (was four). The ten other locales are untouched; the single new string is English-only until the next translate pass.

Commits are unsigned (`--no-gpg-sign`): no TTY for pinentry in this environment.
