### PR TITLE
fix(css): layer the index.css element rules and correct the heading classes

### DIFF
--- a/src/components/section.tsx
+++ b/src/components/section.tsx
@@ -20,7 +20,7 @@ export function PageHeader({
   return (
     <div className="flex flex-wrap items-start justify-between gap-3">
       <div>
-        <h1 className="m-0 text-2xl text-cyber-primary">{title}</h1>
+        <h1 className="m-0 text-3xl text-cyber-text-bright">{title}</h1>
         {description && (
           <p className="mt-1 mb-0 text-sm text-cyber-muted">{description}</p>
         )}

--- a/src/index.css
+++ b/src/index.css
@@ -169,40 +169,42 @@ body:has(.light)::after {
   display: none;
 }
 
-h1 {
-  font-size: var(--text-2xl);
-  font-weight: var(--font-weight-medium);
-  margin-block: 0.5rem;
-  color: var(--color-cyber-primary);
-}
+@layer base {
+  h1 {
+    font-size: var(--text-2xl);
+    font-weight: var(--font-weight-medium);
+    margin-block: 0.5rem;
+    color: var(--color-cyber-primary);
+  }
 
-h2 {
-  font-size: var(--text-xl);
-  font-weight: var(--font-weight-medium);
-  margin-block: 0.5rem;
-  color: var(--color-cyber-primary);
-}
+  h2 {
+    font-size: var(--text-xl);
+    font-weight: var(--font-weight-medium);
+    margin-block: 0.5rem;
+    color: var(--color-cyber-primary);
+  }
 
-h3 {
-  font-size: var(--text-lg);
-  font-weight: var(--font-weight-medium);
-  margin-block: 0.5rem;
-  color: var(--color-cyber-primary);
-}
+  h3 {
+    font-size: var(--text-lg);
+    font-weight: var(--font-weight-medium);
+    margin-block: 0.5rem;
+    color: var(--color-cyber-primary);
+  }
 
-a {
-  text-decoration: none;
-  color: var(--color-cyber-accent);
-  transition: color 0.15s;
-}
+  a {
+    text-decoration: none;
+    color: var(--color-cyber-accent);
+    transition: color 0.15s;
+  }
 
-a:hover {
-  text-decoration: none;
-  color: var(--color-cyber-primary);
-}
+  a:hover {
+    text-decoration: none;
+    color: var(--color-cyber-primary);
+  }
 
-:root:not(.light) a:hover {
-  text-shadow: 0 0 8px oklch(0.8 0.3 142 / 0.4);
+  :root:not(.light) a:hover {
+    text-shadow: 0 0 8px oklch(0.8 0.3 142 / 0.4);
+  }
 }
 
 hr {

--- a/src/pages/account-referral.tsx
+++ b/src/pages/account-referral.tsx
@@ -171,7 +171,7 @@ export function AccountReferralPage() {
           <FormattedMessage defaultMessage="Referral Program" />
         </Eyebrow>
         <div className="flex flex-col gap-2">
-          <h1 className="text-2xl text-cyber-text-bright">
+          <h1 className="text-3xl text-cyber-text-bright">
             <FormattedMessage defaultMessage="Turn your code into commission" />
           </h1>
           <p className="text-cyber-muted text-sm max-w-prose">

--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -146,7 +146,7 @@ export function AppPage() {
             <div className="flex items-center gap-4">
               <AppIcon app={app} size={56} />
               <div>
-                <h1 className="m-0 text-2xl text-cyber-text-bright">
+                <h1 className="m-0 text-3xl text-cyber-text-bright">
                   {app.display_name}
                 </h1>
                 <div className="mt-1 text-cyber-primary tabular-nums">

--- a/src/pages/apps.tsx
+++ b/src/pages/apps.tsx
@@ -71,7 +71,7 @@ export function AppsPage() {
       )}
 
       <div className="flex flex-col gap-2">
-        <h1 className="m-0 text-2xl">
+        <h1 className="m-0 text-3xl text-cyber-text-bright">
           <FormattedMessage defaultMessage="Managed Apps: run the software without running the server" />
         </h1>
         <p className="m-0 max-w-prose text-cyber-muted">

--- a/src/pages/component-gallery.tsx
+++ b/src/pages/component-gallery.tsx
@@ -380,7 +380,7 @@ export default function ComponentGalleryPage() {
   return (
     <div className="flex flex-col gap-6 py-6 max-w-2xl mx-auto">
       <Seo noindex title="Component gallery" />
-      <h1 className="text-xl text-cyber-text-bright">
+      <h1 className="text-3xl text-cyber-text-bright">
         Component gallery
         <span className="ml-2 text-xs text-cyber-muted">
           dev preview — not linked in nav

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -28,7 +28,7 @@ export function ContactPage() {
             "Get in touch with the LNVPS team. Have questions about our VPS hosting or payment options? We're here to help.",
         })}
       />
-      <h1 className="text-xl">
+      <h1 className="text-3xl text-cyber-text-bright">
         <FormattedMessage defaultMessage="Contact LNVPS Support" />
       </h1>
 

--- a/src/pages/news-post.tsx
+++ b/src/pages/news-post.tsx
@@ -47,7 +47,7 @@ export function NewsPostContent({ ev }: { ev: NostrEvent }) {
           jsonLd={newsArticleSchema}
         />
       )}
-      <h1 className="text-2xl">{title}</h1>
+      <h1 className="text-3xl text-cyber-text-bright">{title}</h1>
       <div className="flex items-center justify-between py-8">
         <Profile link={NostrLink.profile(ev.pubkey)} />
         <div>

--- a/src/pages/news.tsx
+++ b/src/pages/news.tsx
@@ -36,7 +36,7 @@ export function NewsPage() {
             "Latest news, updates, and announcements from LNVPS — Bitcoin Lightning VPS hosting with card payments too.",
         })}
       />
-      <h1 className="text-2xl">
+      <h1 className="text-3xl text-cyber-text-bright">
         <FormattedMessage defaultMessage="LNVPS News and Product Updates" />
       </h1>
       {posts.map((a) => (

--- a/src/pages/oauth-complete.tsx
+++ b/src/pages/oauth-complete.tsx
@@ -42,7 +42,7 @@ export default function OAuthCompletePage() {
       <Seo noindex={true} />
       {error ? (
         <>
-          <h1 className="text-cyber-danger">
+          <h1 className="text-3xl text-cyber-danger">
             <FormattedMessage defaultMessage="Sign-in failed" />
           </h1>
           <p className="text-cyber-text text-center max-w-md">

--- a/src/pages/status.tsx
+++ b/src/pages/status.tsx
@@ -573,7 +573,7 @@ export function StatusPage() {
             "Live uptime and incident history for LNVPS services. Check the current operational status of our VPS infrastructure.",
         })}
       />
-      <h1 className="text-2xl">
+      <h1 className="text-3xl text-cyber-text-bright">
         <FormattedMessage defaultMessage="LNVPS Service Status and Uptime" />
       </h1>
       <div className="text-xl flex flex-col gap-2">

--- a/src/pages/vm-firewall.tsx
+++ b/src/pages/vm-firewall.tsx
@@ -351,7 +351,7 @@ export function VmFirewallPage() {
   if (!state) {
     return (
       <div className="flex flex-col gap-2">
-        <h1>
+        <h1 className="text-3xl text-cyber-text-bright">
           <FormattedMessage defaultMessage="Firewall" />
         </h1>
         <div className="text-cyber-danger">

--- a/src/pages/vm-history.tsx
+++ b/src/pages/vm-history.tsx
@@ -171,7 +171,7 @@ export function VmHistoryPage() {
   if (!state) {
     return (
       <div className="flex flex-col gap-2">
-        <h1>
+        <h1 className="text-3xl text-cyber-text-bright">
           <FormattedMessage defaultMessage="VM History" />
         </h1>
         <div className="text-cyber-danger">


### PR DESCRIPTION
Closes #58. Option 2 from the draft, per Jessica: layer the element rules **and** correct the classes in the same PR, so `main` never renders a look nobody picked.

`@import "tailwindcss"` puts every utility in `@layer utilities`, and unlayered CSS beats all layered CSS regardless of specificity. The `h1`/`h2`/`h3`/`a` rules at `src/index.css:172-206` were unlayered, so they overrode every Tailwind `text-*` utility on the site — 47 headings in `src/`, 35 of them carrying a size or colour class that did nothing.

## Two commits

**`cefa323`** wraps the block in `@layer base`. Two lines of real diff; the element rules still style anything with no utility of its own.

**`ee300ae`** corrects the classes that layering makes visible:

- **Every page-title h1 is `text-3xl`.** They were a mix of `text-2xl`, `text-xl` and no class — invisible before, because the element rule pinned all of them to 22.5px. `PageHeader` (`src/components/section.tsx:23`) carries about ten account pages on its own.
- **Every page-title h1 is `text-cyber-text-bright`.** *This is the part worth arguing with.* Today the site is uniformly green, because the unlayered rule beat the colour utilities too. Layering alone would have shipped bright on `/`, `/apps/:id`, `/account/referral` and the three landing pages and green on `/apps`, `/news`, `/contact`, `/status` and the account area — purely by which file had thought to write a colour. Mixed is the one result nobody chose, so it is uniform on Jessica's recommendation. @v0l has the brand call: the revert is one class per h1, `text-cyber-text-bright` → `text-cyber-primary`, and `section.tsx` covers the whole account area in one line.

## Left alone deliberately

| | why |
|---|---|
| `oauth-complete.tsx:45` keeps `text-cyber-danger` | error-state h1; the colour is semantic, not brand |
| `markdown.tsx:29` keeps `text-2xl` | README / article body heading, not a page title |
| card + list h2s (`apps.tsx:31`, `account.tsx:64`, `news.tsx:49`) keep `text-cyber-text-bright` | inside bordered panels; not the section-heading level |
| every classless `h1`/`h2`/`h3` | the element rule still styles them — this is what keeps "section h2 green" true |
| `hr`, `input`, `textarea`, `select` (also unlayered) | out of scope for #58; no utility is fighting them |

## Measured, not eyeballed

Computed styles in headless Chrome against the production build at `ee300ae`. Note `--text-3xl` is **28.125px** here, not 30px: `html` sets a 15px base, so every rem figure in the issue scales by 15/16.

```
/                        h1 28.125px bright    h2 11.25px muted   (eyebrow)
/apps                    h1 28.125px bright    h2 15px bright     (card)
/apps/3                  h1 28.125px bright
/blossom-server-hosting  h1 28.125px bright    h2 11.25px muted   (eyebrow ×5)
/news                    h1 28.125px bright    h2 18.75px bright  (list item)
/contact                 h1 28.125px bright
/status                  h1 28.125px bright

injected bare h1/h2/h3   22.5 / 18.75 / 16.875px, all cyber-primary  ← element rule intact
injected bare <a>        cyber-accent                                ← element rule intact
injected h2.text-xs.text-cyber-muted   11.25px muted                 ← utility now wins
```

The eyebrow was the point: `SectionHeading` asks for `text-xs text-cyber-muted` and rendered 18.75px bright green, because `uppercase` and `tracking-[0.2em]` are not font properties and did apply. It is now 11.25px muted on every page that builds one.

Screenshots — [`/`](https://apex-strata.communities.buzz.xyz/media/ebe03d86d8aa1b0b0a93314f4aeeb541e4954e073471a05423100e180c0038ad.png), [`/apps`](https://apex-strata.communities.buzz.xyz/media/2921b9a31f6a16fb08f0ea920bf10acd904bb5da84bafa37772fa982ad1e251d.png). That media host has been 401ing for at least one reviewer, which is why the table above is the primary artifact.

## Checks

`bunx tsc --noEmit` clean, `bun run build` exit 0, `bunx prettier --check src/index.css` passes. `src/pages/app.tsx` and `src/pages/vm-firewall.tsx` fail `prettier --check` **both before and after** this change — 37 files under `src/` do on `main`, and I have not reformatted them here. Commits are unsigned (`--no-gpg-sign`): no TTY for pinentry.
