### PR TITLE
fix(login): land somewhere on the site after signing in

### DIFF
--- a/src/pages/sign-up.tsx
+++ b/src/pages/sign-up.tsx
@@ -13,11 +13,26 @@ import {
   isWebauthnCancellation,
   passkeyRegister,
 } from "../webauthn";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { FormattedMessage, useIntl } from "react-intl";
 import Seo from "../components/seo";
 import { Relays } from "../const";
 
 type Mode = "signin" | "create";
+
+/**
+ * Is `next` a path on this site?
+ *
+ * `?next=` is attacker-controllable and this is the login page, so only a
+ * same-origin *path* is ever followed: one leading slash, and no second slash
+ * or backslash after it — a browser reads both `//evil.com` and `/\evil.com`
+ * as protocol-relative URLs and would leave the site. Anything else is
+ * ignored rather than rejected loudly; the user still gets signed in and lands
+ * somewhere sensible.
+ */
+function isInternalPath(next: string): boolean {
+  return /^\/(?![/\\])/.test(next);
+}
 
 /**
  * Types out a shell command one character at a time. Re-types whenever `text`
@@ -60,6 +75,36 @@ export default function SignUpPage() {
   const [key, setKey] = useState<PrivateKeySigner>();
   const system = useContext(SnortContext);
   const { formatMessage } = useIntl();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
+
+  /**
+   * Where to send someone who has just signed in or created an account.
+   *
+   * This used to be `window.history.back()` unconditionally, which is right
+   * only when `/login` was reached from another LNVPS page. When the login
+   * page is the first entry in the tab — a shared link, a bookmark, a search
+   * result, a link from a Nostr client — going back leaves the site entirely,
+   * so a successful sign-in reads as a failed one (`LNVPS/web#42`).
+   *
+   * `location.key` is React Router's answer to "did this app render a page
+   * before this one": it is `"default"` for whatever the tab landed on and a
+   * generated id for anything pushed since, and it survives a reload because
+   * the id lives in the history entry's state. `document.referrer` would not
+   * do — a referrer policy can strip it, and having one does not put the page
+   * in this tab's history.
+   */
+  function onAuthenticated() {
+    const next = searchParams.get("next");
+    if (next && isInternalPath(next)) {
+      navigate(next, { replace: true });
+    } else if (location.key !== "default") {
+      navigate(-1);
+    } else {
+      navigate("/account", { replace: true });
+    }
+  }
 
   async function uploadImage() {
     const f = await openFile();
@@ -70,7 +115,7 @@ export default function SignUpPage() {
     setError("");
     try {
       await passkeyRegister(name || undefined);
-      window.history.back();
+      onAuthenticated();
     } catch (e) {
       if (isWebauthnCancellation(e)) return;
       setError(
@@ -108,7 +153,7 @@ export default function SignUpPage() {
     system.BroadcastEvent(ev);
     system.BroadcastEvent(relayList);
     LoginState.loginPrivateKey(key.privateKey);
-    window.history.back();
+    onAuthenticated();
   }
 
   return (
@@ -166,11 +211,7 @@ export default function SignUpPage() {
             </div>
 
             {mode === "signin" ? (
-              <Login
-                onLogin={() => {
-                  window.history.back();
-                }}
-              />
+              <Login onLogin={onAuthenticated} />
             ) : (
               <CreateAccount
                 name={name}


### PR DESCRIPTION
Closes #42.

All three success paths on `/login` ended in `window.history.back()` — sign-in (`sign-up.tsx:170`), account creation (`:111`), passkey registration (`:73`). Right when the page was reached from another LNVPS page; when `/login` is the tab's first entry it walks *off* the site. The session is written either way (`src/login.ts:59-68`), so a sign-in that succeeded reads as one that failed.

## What it does now

One `onAuthenticated()`, in order:

1. `?next=`, if it is a path on this site
2. `navigate(-1)`, if this app instance rendered a page before this one
3. `/account`

**`location.key` is the test for (2).** React Router gives the location the tab landed on the key `"default"`, and anything pushed since a generated id — and that id lives in the history entry's state, so it survives a reload. `document.referrer` would not do: a referrer policy can strip it, and having one does not put the page in this tab's history.

Worth knowing: this tracks the *app session*, not the browser stack. Someone who types `/login` into the address bar while an LNVPS page is behind them gets `/account` rather than a back-step. That is the deliberate trade — it never leaves the site.

**`?next=` is validated.** It is attacker-controllable on a login page, so `isInternalPath` takes one leading slash and rejects a second slash or a backslash after it: a browser reads `//evil.example` and `/\evil.example` as protocol-relative and would leave the site. A rejected value falls through to (2)/(3) instead of erroring — the user is signed in regardless.

**Nothing sets `next` today.** The four in-app entries to `/login` (`app.tsx:297`, `ip-block-card.tsx:65`, `login-button.tsx:16`, `oauth-complete.tsx:53`) are all in-app navigations, covered by (2). The parameter is here so whoever adds the first such link has a validated one to use rather than inventing it.

`oauth-complete.tsx` was checked and does not share the bug — it has always navigated to `/`.

## Verification

Driven in headless Chrome against the production build, five cases, each in a fresh tab with storage cleared over CDP rather than by navigating first — a setup navigation leaves a history entry and stops it being the case at issue. That detail matters: my first harness cleared storage by navigating, and it hid the bug behind an extra history entry.

| case | `origin/main` (`d51805f`) | this branch (`7f327fb`) |
|---|---|---|
| direct landing on `/login` | **about:blank** | `/account` |
| reached `/login` from `/` in-app | `/` | `/` |
| `?next=/apps` | **about:blank** | `/apps` |
| `?next=//evil.example` | **about:blank** | `/account` |
| `?next=https://evil.example` | **about:blank** | `/account` |

`bunx tsc --noEmit` clean, `bun run build` exit 0, `prettier --check src/pages/sign-up.tsx` passes. No new strings, so no locale churn. Commit is unsigned (`--no-gpg-sign`): no TTY for pinentry here.
