### PR TITLE
fix(apps): take Route96's storage split off the catalog

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -643,6 +643,29 @@ export interface App {
   storage_bytes: number;
   /** Per-service footprint breakdown (sums to the totals above). */
   services: Array<AppServiceResources>;
+  /**
+   * Per-volume storage breakdown, summing to `storage_bytes` (LNVPS/api#260).
+   *
+   * Optional because an API older than that release does not send it at all —
+   * not because an app may have no volumes, which arrives as `[]`.
+   */
+  volumes?: Array<AppVolume>;
+}
+
+/** One persistent volume of an app (LNVPS/api#260). */
+export interface AppVolume {
+  /** Compose service it belongs to; a volume name is only unique within one. */
+  service: string;
+  /** Compose volume name — internal plumbing. Render `label`, not this. */
+  name: string;
+  /**
+   * What the buyer gets from it: `events`, `media`, `database`. Authored per
+   * app, so it arrives over the wire in English and is never translated.
+   * Absent for volumes nobody shops for (`run`, `packs`).
+   */
+  label?: string;
+  /** Size in bytes. These sum to `storage_bytes`. */
+  size_bytes: number;
 }
 
 /** One service's share of an app's resource footprint. */

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -14,6 +14,9 @@
   "+EHk4e": {
     "defaultMessage": "Yes. It is your machine — install what you like."
   },
+  "+H6Rvj": {
+    "defaultMessage": "Run your own Blossom and NIP-96 media server for {price}/month. Route96, up in minutes on its own hostname with persistent storage and TLS included."
+  },
   "+JVG/q": {
     "defaultMessage": "{n, plural, one {year} other {years}}"
   },
@@ -100,6 +103,9 @@
   },
   "1M3SKY": {
     "defaultMessage": "Please describe your question or issue in detail..."
+  },
+  "1R0JfT": {
+    "defaultMessage": "{storage} of persistent storage — {breakdown}"
   },
   "1VQrBL": {
     "defaultMessage": "{h, plural, one {# hr} other {# hrs}} {m, plural, one {# min} other {# mins}}"
@@ -884,6 +890,9 @@
   "MTnSwY": {
     "defaultMessage": "ex. tax"
   },
+  "MfiEGP": {
+    "defaultMessage": "{storage} in total. For a personal media server that is comfortable; if you need more, a VPS with Route96 installed yourself scales further."
+  },
   "Mp+zDS": {
     "defaultMessage": "This component only supports Lightning payments"
   },
@@ -1246,6 +1255,9 @@
   },
   "VzzYJk": {
     "defaultMessage": "Create"
+  },
+  "W16obH": {
+    "defaultMessage": "{breakdown}, {storage} in total. For a personal media server that is comfortable; if you need more, a VPS with Route96 installed yourself scales further."
   },
   "W8nHSd": {
     "defaultMessage": "FAQ"
@@ -1679,9 +1691,6 @@
   "jf7fbc": {
     "defaultMessage": "None set — add one"
   },
-  "jgrdHK": {
-    "defaultMessage": "20 GB of files, with a separate 5 GB volume for the database. For a personal media server that is comfortable; if you need more, a VPS with Route96 installed yourself scales further."
-  },
   "jhBqwg": {
     "defaultMessage": "Point a CNAME for this domain at the deployment hostname once it is assigned. Leave empty to remove."
   },
@@ -1909,9 +1918,6 @@
   },
   "p5LNtB": {
     "defaultMessage": "Not set"
-  },
-  "pJmk+U": {
-    "defaultMessage": "Run your own Blossom and NIP-96 media server for {price}/month. Route96, up in minutes on its own hostname with 20 GB for your files and TLS included."
   },
   "pYX859": {
     "defaultMessage": "Deleting"
@@ -2165,9 +2171,6 @@
   "x0cZXf": {
     "defaultMessage": "Upgrade Not Available"
   },
-  "x27Qqd": {
-    "defaultMessage": "20 GB persistent storage for your files, plus a 5 GB database volume of its own — 25 GB allocated in total"
-  },
   "xExBHw": {
     "defaultMessage": "Your own hostname — <code>your-name.ie.apps.lnvps.cloud</code> — with automatic TLS"
   },
@@ -2251,5 +2254,8 @@
   },
   "zbyKVt": {
     "defaultMessage": "<b>Unmetered traffic.</b> A routing node gossips constantly. You should not be watching a bandwidth meter."
+  },
+  "zzkKCh": {
+    "defaultMessage": "{storage} of persistent storage"
   }
 }

--- a/src/pages/blossom-server-hosting.tsx
+++ b/src/pages/blossom-server-hosting.tsx
@@ -6,6 +6,7 @@ import { CostAmount } from "../components/cost";
 import { appJsonLd } from "../utils/app-seo";
 import { faqJsonLd, type FaqItem } from "../utils/faq-seo";
 import { formatPriceText } from "../utils/currency";
+import { formatBytesText } from "../utils/bytes";
 import { BlossomAppId } from "../const";
 import type { AppLoaderData } from "../loaders";
 
@@ -66,14 +67,22 @@ function Section({
  * markup and the `<title>` cannot disagree, and no locale file carries the
  * number.
  *
- * Storage is deliberately NOT that shape, and this is the one place on the site
- * where a written figure beats a derived one (`LNVPS/web#60`). `storage_bytes`
- * is 25 GiB — the sum of two fixed volumes, `blobs` 20Gi for uploads and `data`
- * 5Gi for the database — and nothing in the API says which is which. Rendering
- * the sum tells a buyer they have 25 GB for files when they have 20; rendering
- * the sum next to a written split is the one version that can contradict itself
- * the day the app is resized. So both slots stay literal until `LNVPS/api#260`
- * gives volumes a label, and web#60 stays open on it.
+ * Storage now works the same way (`LNVPS/web#60`). It could not before:
+ * `storage_bytes` is only the 25 GiB total, and printing that where the copy
+ * says "for your files" tells a buyer they have 25 GB of room for uploads when
+ * they have 20. The split lives in the compose volumes, which the client is
+ * not allowed to read. `LNVPS/api#260` fixed that at the source — each volume
+ * now arrives with the purpose its app authored — so the page renders what the
+ * catalog says and no locale file carries a size.
+ *
+ * Three states, in order:
+ *
+ * - **labelled volumes** — the total and the breakdown, e.g. "25GB of
+ *   persistent storage — 20GB files and 5GB database".
+ * - **no labels** (an app that authored none, or a catalog row not yet
+ *   patched) — the plain total. Honest, less specific.
+ * - **no catalog** (API unreachable) — no storage claim at all, rather than a
+ *   size written into the front end.
  */
 export function BlossomServerHostingPage() {
   const intl = useIntl();
@@ -91,6 +100,25 @@ export function BlossomServerHostingPage() {
   const priceText = formatPriceText(intl, price);
   const priceNode = <CostAmount cost={price} converted={false} />;
 
+  // The catalog's storage, or no claim at all — there is no fallback constant,
+  // because a size written into the front end is product data the client has
+  // no business holding.
+  const storage = app ? formatBytesText(intl, app.storage_bytes) : undefined;
+
+  // Only volumes the app gave a purpose. An unlabelled one is still real
+  // storage and still inside `storage_bytes`; it is simply not something to
+  // name, so it is counted in the total and left out of the breakdown.
+  // `label` is authored per app and arrives in English, which is why it is
+  // interpolated rather than translated — the sizes around it are formatted
+  // for the locale.
+  const named = (app?.volumes ?? []).filter((v) => v.label);
+  const breakdown = named.length
+    ? intl.formatList(
+        named.map((v) => `${formatBytesText(intl, v.size_bytes)} ${v.label}`),
+        { type: "conjunction" },
+      )
+    : undefined;
+
   // Rendered as the FAQ block *and* handed to `faqJsonLd`, so the two can
   // never say different things. Answers ship as written — expanding one
   // usually costs `FAQPage` eligibility.
@@ -106,16 +134,34 @@ export function BlossomServerHostingPage() {
           "A protocol for storing and retrieving files addressed by their hash, designed to work with Nostr. NIP-96 is the older HTTP file-storage spec — Route96 speaks both.",
       }),
     },
-    // Written, not derived, and unconditional with it: `storage_bytes` only
-    // knows the 25 GiB total, and "25GB" here reads as 25 GB of room for
-    // uploads when the answer is 20. See the note on the component above.
-    {
-      question: formatMessage({ defaultMessage: "How much can I store?" }),
-      answer: formatMessage({
-        defaultMessage:
-          "20 GB of files, with a separate 5 GB volume for the database. For a personal media server that is comfortable; if you need more, a VPS with Route96 installed yourself scales further.",
-      }),
-    },
+    // The answer *is* the catalog's storage, so with the catalog unreachable
+    // there is nothing honest to put in it and the question is not asked.
+    // Dropping the item drops it from the rendered `<dl>` and from `faqJsonLd`
+    // together, which is why the two share this array.
+    ...(storage
+      ? [
+          {
+            question: formatMessage({
+              defaultMessage: "How much can I store?",
+            }),
+            answer: breakdown
+              ? formatMessage(
+                  {
+                    defaultMessage:
+                      "{breakdown}, {storage} in total. For a personal media server that is comfortable; if you need more, a VPS with Route96 installed yourself scales further.",
+                  },
+                  { breakdown, storage },
+                )
+              : formatMessage(
+                  {
+                    defaultMessage:
+                      "{storage} in total. For a personal media server that is comfortable; if you need more, a VPS with Route96 installed yourself scales further.",
+                  },
+                  { storage },
+                ),
+          },
+        ]
+      : []),
     {
       question: formatMessage({
         defaultMessage: "How large a file can I upload?",
@@ -148,7 +194,7 @@ export function BlossomServerHostingPage() {
         description={formatMessage(
           {
             defaultMessage:
-              "Run your own Blossom and NIP-96 media server for {price}/month. Route96, up in minutes on its own hostname with 20 GB for your files and TLS included.",
+              "Run your own Blossom and NIP-96 media server for {price}/month. Route96, up in minutes on its own hostname with persistent storage and TLS included.",
           },
           { price: priceText },
         )}
@@ -200,9 +246,21 @@ export function BlossomServerHostingPage() {
 
         <Section title={<FormattedMessage defaultMessage="What is included" />}>
           <ul className="m-0 flex max-w-prose list-disc flex-col gap-1 pl-5 text-cyber-text">
-            <li>
-              <FormattedMessage defaultMessage="20 GB persistent storage for your files, plus a 5 GB database volume of its own — 25 GB allocated in total" />
-            </li>
+            {storage ? (
+              <li>
+                {breakdown ? (
+                  <FormattedMessage
+                    defaultMessage="{storage} of persistent storage — {breakdown}"
+                    values={{ storage, breakdown }}
+                  />
+                ) : (
+                  <FormattedMessage
+                    defaultMessage="{storage} of persistent storage"
+                    values={{ storage }}
+                  />
+                )}
+              </li>
+            ) : null}
             <li>
               <FormattedMessage defaultMessage="Uploads up to 100 MB each" />
             </li>


### PR DESCRIPTION
Closes #60.

`/blossom-server-hosting` wrote Route96's disk into translatable copy in three places — the "What is included" bullet (`x27Qqd`), the "How much can I store?" answer (`jgrdHK`) and the meta description (`pJmk+U`) — so changing the allocation meant editing eleven locale files rather than one catalog row.

That stayed literal on #61 for a good reason: `storage_bytes` is only the 25 GiB total, and printing it where the copy says "for your files" claims 25 GB of upload room when the answer is 20. LNVPS/api#260 fixed it at the source — each volume now arrives as `{ service, name, label, size_bytes }` with the purpose authored by whoever wrote the app.

## ⚠️ Merging this before the catalog is patched loses the split

api#262's own commit message: *"The live catalog rows are unchanged — they carry no labels until someone with admin credentials patches them, and until then every app reports its plain total."*

So until route96's compose is PATCHed with `label:` on `blobs` and `data`, this page falls to **"25GB of persistent storage"** — honest, but less specific than the literal it replaces. @v0l that PATCH is on your list after the API deploy; this wants to land after it, or land knowing the page is briefly vaguer.

## Three states, in order

| catalog | bullet | FAQ answer |
|---|---|---|
| labelled volumes | `25GB of persistent storage — 20GB files and 5GB database` | `20GB files and 5GB database, 25GB in total. …` |
| volumes, no labels | `25GB of persistent storage` | `25GB in total. …` |
| no `volumes` field (API older than #260) | `25GB of persistent storage` | `25GB in total. …` |
| API unreachable | *(no bullet)* | *(question not asked)* |

The last one drops the FAQ item from the rendered `<dl>` **and** from `faqJsonLd` together — the two share one array, so they cannot disagree.

## Details worth reviewing

- **Only labelled volumes are named.** An unlabelled one is still real storage and still inside the total, so it is counted and left unnamed rather than printed as `run 1GB`.
- **`label` is English over the wire.** Authored per app, never translated — same as `seo_description`. So it is interpolated, with the sizes around it formatted for the locale and the list joined by `intl.formatList`.
- **`App.volumes` is optional** in `src/api.ts` — not because an app may have no volumes (that arrives as `[]`) but because an API older than #260 omits the field. Without that the page would throw on the currently-deployed API.
- **The meta description drops its figure** rather than gaining a second variant for the API-down render. It costs a number in the SERP snippet — @Jessica's call if that is the wrong trade.

## Still literal, out of scope

"Uploads up to 100 MB each" is `max_upload_bytes` inside the route96 service's config file, not an API field. Filed separately rather than derived — reaching for a key only one app has is the volume-label map in another shape.

## Checks

Rendered with `server/prod.ts` against a stub catalog in each shape above; API-down render has no `Product` block and no "GB" anywhere in the served HTML. `bunx tsc --noEmit` clean, `bun run build` exit 0. `src/api.ts` fails `prettier --check` both before and after this change and is not reformatted here. Commit unsigned (`--no-gpg-sign`): no pinentry TTY.
