### PR TITLE
feat(apps): gate the deployment page on one derived lifecycle

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -704,6 +704,16 @@ export type AppDeploymentStatus =
   | "error"
   | "deleting";
 
+/**
+ * Billing verdict on a deployment's subscription (LNVPS/api#253).
+ *
+ * `unpaid` is "the first payment has never been confirmed", not "overdue" —
+ * a subscription never paid for reports `unpaid` whatever its expiry says,
+ * because asking someone to renew what they never bought is worse than asking
+ * them to buy it.
+ */
+export type AppDeploymentBillingState = "unpaid" | "active" | "expired";
+
 /** A user's running instance of a catalog app. */
 export interface AppDeployment {
   id: number;
@@ -721,6 +731,20 @@ export interface AppDeployment {
   status_message?: string;
   /** Subscription this deployment is billed under (renew via the subscription endpoints). */
   subscription_id?: number;
+  /**
+   * Whether the subscription behind this deployment has ever been paid, and
+   * whether it has lapsed (LNVPS/api#253).
+   *
+   * Independent of `status` and `desired_state` on purpose: a never-paid
+   * deployment is written back by the operator as `stopped`, so status alone
+   * cannot tell "never paid for" from "the customer stopped it".
+   *
+   * `null`/absent means the subscription could not be resolved — the same
+   * condition that leaves `subscription_id` unset. That is an operational
+   * fault, not a billing verdict: treat it as unknown, never as `unpaid`, or
+   * a paying customer gets asked for money again.
+   */
+  billing_state?: AppDeploymentBillingState | null;
   /**
    * Size as a multiple of the catalog app's base footprint and price; `1` is
    * the base app. Raised via the upgrade endpoints, never lowered.

--- a/src/components/deploy-app-form.tsx
+++ b/src/components/deploy-app-form.tsx
@@ -15,18 +15,27 @@ export function ConfigInput({
   field,
   value,
   onChange,
+  disabled,
 }: {
   field: AppConfigField;
   value: string;
   onChange: (v: string) => void;
+  /** Show the value without letting it be edited (see `LNVPS/web#54`). */
+  disabled?: boolean;
 }) {
   const label = field.label ?? field.name;
   if (field.type === "bool") {
     return (
-      <label className="flex items-center gap-2 text-sm text-cyber-text cursor-pointer select-none">
+      <label
+        className={
+          "flex items-center gap-2 text-sm text-cyber-text select-none " +
+          (disabled ? "opacity-60" : "cursor-pointer")
+        }
+      >
         <input
           type="checkbox"
           checked={value === "true"}
+          disabled={disabled}
           onChange={(e) => onChange(e.target.checked ? "true" : "false")}
         />
         {label}
@@ -34,7 +43,7 @@ export function ConfigInput({
     );
   }
   return (
-    <label className="flex flex-col gap-1">
+    <label className={"flex flex-col gap-1 " + (disabled ? "opacity-60" : "")}>
       <span className="text-[0.65rem] uppercase tracking-[0.2em] text-cyber-text">
         {label}
         {field.required && <span className="text-cyber-danger"> *</span>}
@@ -43,6 +52,7 @@ export function ConfigInput({
         <textarea
           rows={4}
           value={value}
+          disabled={disabled}
           onChange={(e) => onChange(e.target.value)}
           className="font-mono text-xs"
         />
@@ -50,6 +60,7 @@ export function ConfigInput({
         <input
           type={field.type === "int" ? "number" : "text"}
           value={value}
+          disabled={disabled}
           onChange={(e) => onChange(e.target.value)}
         />
       )}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -161,6 +161,9 @@
   "36aVfS": {
     "defaultMessage": "Nostr DM"
   },
+  "375584": {
+    "defaultMessage": "Needs payment"
+  },
   "3GLHv9": {
     "defaultMessage": "authenticate"
   },
@@ -328,6 +331,9 @@
   },
   "7agV2X": {
     "defaultMessage": "Relay"
+  },
+  "7bTzvm": {
+    "defaultMessage": "Setting up — this usually takes a minute. The endpoint appears once it is running."
   },
   "7fGyF+": {
     "defaultMessage": "Wipe & reinstall"
@@ -764,6 +770,9 @@
   "ID2dFf": {
     "defaultMessage": "No NWC wallet saved yet. Add one below to receive payouts."
   },
+  "IDpruN": {
+    "defaultMessage": "Deploying"
+  },
   "ILTAun": {
     "defaultMessage": "Your VM is being provisioned. This usually takes a minute or two."
   },
@@ -805,6 +814,9 @@
   },
   "JVClQM": {
     "defaultMessage": "LNVPS Service Status and Uptime"
+  },
+  "JVZcdC": {
+    "defaultMessage": "This deployment's subscription has expired and it has been scaled to zero. Your data is still here — renew to start it again."
   },
   "JiCBWy": {
     "defaultMessage": "Connect over SSH with your selected key."
@@ -1538,6 +1550,9 @@
   "exrlwL": {
     "defaultMessage": "Lowercase letters, digits and hyphens. Becomes your subdomain."
   },
+  "f+jGyB": {
+    "defaultMessage": "Deleting stops billing and permanently removes the deployment and its volumes."
+  },
   "f00p/7": {
     "defaultMessage": "Upload failed"
   },
@@ -1837,6 +1852,9 @@
   },
   "nFQbxh": {
     "defaultMessage": "Payment Method"
+  },
+  "nQHBG0": {
+    "defaultMessage": "Settings can be changed once this deployment is paid for and running."
   },
   "nWQFic": {
     "defaultMessage": "Renew"

--- a/src/pages/account-app-deployment.tsx
+++ b/src/pages/account-app-deployment.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { ReactNode, useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { FormattedDate, FormattedMessage } from "react-intl";
 import {
@@ -19,17 +19,126 @@ import { AsyncButton } from "../components/button";
 import { CostAmount } from "../components/cost";
 import PaymentFlow from "../components/payment-flow";
 import { appUpgradeSource } from "../components/payment-sources";
-import { AppIcon, AppResources, deploymentStatus } from "./account-apps";
+import { AppIcon, AppResources } from "./account-apps";
+import {
+  DeploymentLifecycle,
+  deploymentLifecycle,
+  deploymentPermissions,
+} from "../utils/app-deployment";
+import type { BillingTone } from "../components/billing";
 
-/** Edit a deployment's instance name and config field values. */
+/** Pill tone and label for a lifecycle state. */
+function lifecyclePill(lifecycle: DeploymentLifecycle): {
+  tone: BillingTone;
+  label: ReactNode;
+} {
+  switch (lifecycle) {
+    case "unpaid":
+      return {
+        tone: "warning",
+        label: <FormattedMessage defaultMessage="Needs payment" />,
+      };
+    case "expired":
+      return {
+        tone: "warning",
+        label: <FormattedMessage defaultMessage="Expired" />,
+      };
+    case "deploying":
+      return {
+        tone: "warning",
+        label: <FormattedMessage defaultMessage="Deploying" />,
+      };
+    case "running":
+      return {
+        tone: "primary",
+        label: <FormattedMessage defaultMessage="Running" />,
+      };
+    case "stopped":
+      return {
+        tone: "muted",
+        label: <FormattedMessage defaultMessage="Stopped" />,
+      };
+    case "deleting":
+      return {
+        tone: "danger",
+        label: <FormattedMessage defaultMessage="Deleting" />,
+      };
+    case "error":
+      return {
+        tone: "danger",
+        label: <FormattedMessage defaultMessage="Error" />,
+      };
+  }
+}
+
+/**
+ * The three steps a deployment walks on its way to serving traffic, which is
+ * what Kieran asked to see: needs payment → deploying → running.
+ *
+ * Only rendered on that path. Stopped, expired, errored and deleting are not
+ * points along it — a progress bar reading "2 of 3" on a deployment the
+ * customer stopped on purpose says nothing true — so those states show the
+ * status pill alone.
+ */
+function LifecycleProgress({ lifecycle }: { lifecycle: DeploymentLifecycle }) {
+  const steps: Array<{ key: DeploymentLifecycle; label: ReactNode }> = [
+    { key: "unpaid", label: <FormattedMessage defaultMessage="Payment" /> },
+    {
+      key: "deploying",
+      label: <FormattedMessage defaultMessage="Deploying" />,
+    },
+    { key: "running", label: <FormattedMessage defaultMessage="Running" /> },
+  ];
+  const at = steps.findIndex((s) => s.key === lifecycle);
+  if (at === -1) return null;
+
+  return (
+    <ol className="m-0 flex list-none flex-wrap items-center gap-2 p-0 text-[0.65rem] uppercase tracking-[0.2em]">
+      {steps.map((s, i) => (
+        <li key={String(s.key)} className="flex items-center gap-2">
+          {i > 0 && (
+            <span
+              aria-hidden
+              className={
+                "h-px w-6 " + (i <= at ? "bg-cyber-primary" : "bg-cyber-border")
+              }
+            />
+          )}
+          <span
+            className={
+              i < at
+                ? "text-cyber-primary"
+                : i === at
+                  ? "text-cyber-text-bright"
+                  : "text-cyber-muted"
+            }
+            aria-current={i === at ? "step" : undefined}
+          >
+            {s.label}
+          </span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+/**
+ * Edit a deployment's instance name and config field values.
+ *
+ * `readOnly` shows the same values without letting them be changed, for the
+ * states where there is nothing to apply them to yet — the settings are worth
+ * reading before paying, and a save that the API would refuse is not.
+ */
 function ConfigEditor({
   app,
   deployment,
+  readOnly,
   onSaved,
   onError,
 }: {
   app: App;
   deployment: AppDeployment;
+  readOnly?: boolean;
   onSaved: (d: AppDeployment) => void;
   onError: (msg: string) => void;
 }) {
@@ -76,6 +185,7 @@ function ConfigEditor({
           type="text"
           value={name}
           maxLength={40}
+          disabled={readOnly}
           onChange={(e) => setName(e.target.value.toLowerCase())}
         />
         {nameChanged && (
@@ -93,6 +203,7 @@ function ConfigEditor({
           type="text"
           value={customDomain}
           placeholder="blog.example.com"
+          disabled={readOnly}
           onChange={(e) => setCustomDomain(e.target.value.toLowerCase())}
         />
         <span className="text-xs text-cyber-muted">
@@ -120,6 +231,7 @@ function ConfigEditor({
               key={f.name}
               field={f}
               value={values[f.name] ?? f.default ?? ""}
+              disabled={readOnly}
               onChange={(v) => setValues((s) => ({ ...s, [f.name]: v }))}
             />
           ))}
@@ -129,24 +241,30 @@ function ConfigEditor({
         </div>
       )}
 
-      <div className="flex items-center gap-3">
-        <AsyncButton
-          disabled={!canSave}
-          className={
-            canSave
-              ? "bg-cyber-primary/20 border-cyber-primary text-cyber-primary hover:bg-cyber-primary/30 hover:shadow-neon"
-              : "opacity-50 cursor-not-allowed"
-          }
-          onClick={save}
-        >
-          <FormattedMessage defaultMessage="Save changes" />
-        </AsyncButton>
-        {saved && (
-          <span className="text-xs text-cyber-primary">
-            <FormattedMessage defaultMessage="Saved. The app will restart shortly." />
-          </span>
-        )}
-      </div>
+      {readOnly ? (
+        <p className="m-0 text-xs text-cyber-muted">
+          <FormattedMessage defaultMessage="Settings can be changed once this deployment is paid for and running." />
+        </p>
+      ) : (
+        <div className="flex items-center gap-3">
+          <AsyncButton
+            disabled={!canSave}
+            className={
+              canSave
+                ? "bg-cyber-primary/20 border-cyber-primary text-cyber-primary hover:bg-cyber-primary/30 hover:shadow-neon"
+                : "opacity-50 cursor-not-allowed"
+            }
+            onClick={save}
+          >
+            <FormattedMessage defaultMessage="Save changes" />
+          </AsyncButton>
+          {saved && (
+            <span className="text-xs text-cyber-primary">
+              <FormattedMessage defaultMessage="Saved. The app will restart shortly." />
+            </span>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -484,10 +602,12 @@ export function AccountAppDeploymentPage() {
     );
   }
 
-  const st = deploymentStatus(deployment.status);
-  const isPending = deployment.status === "pending";
-  const isRunning = deployment.status === "running";
-  const isStopped = deployment.status === "stopped";
+  // One derived state drives the pill, the banner and every section gate, so
+  // the page cannot say "stopped" in the header and offer a resize quote
+  // underneath.
+  const lifecycle = deploymentLifecycle(deployment);
+  const can = deploymentPermissions(lifecycle);
+  const st = lifecyclePill(lifecycle);
 
   return (
     <div className="flex flex-col gap-6">
@@ -510,9 +630,15 @@ export function AccountAppDeploymentPage() {
         actions={<StatusPill tone={st.tone}>{st.label}</StatusPill>}
       />
 
+      <LifecycleProgress lifecycle={lifecycle} />
+
       {error && <b className="text-cyber-danger">{error}</b>}
 
-      {isPending && deployment.subscription_id && (
+      {/* The banner is the state's one call to action, so at most one shows.
+          `unpaid` and `expired` both need the subscription to act on; without
+          a `subscription_id` there is nowhere to send the customer, so the
+          pill carries the state alone rather than offering a dead link. */}
+      {lifecycle === "unpaid" && deployment.subscription_id && (
         <div className="flex flex-wrap items-center justify-between gap-3 rounded-sm border border-cyber-warning/50 bg-cyber-warning/10 px-4 py-3">
           <span className="text-sm text-cyber-text">
             <FormattedMessage defaultMessage="This deployment is awaiting payment. Pay its subscription to activate it." />
@@ -523,6 +649,38 @@ export function AccountAppDeploymentPage() {
           >
             <FormattedMessage defaultMessage="Pay to activate" />
           </Link>
+        </div>
+      )}
+
+      {lifecycle === "expired" && deployment.subscription_id && (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-sm border border-cyber-warning/50 bg-cyber-warning/10 px-4 py-3">
+          {/* "Your data is still here" is the load-bearing half: the operator
+              keeps the volumes on expiry, and a customer who believes they are
+              gone has no reason to renew. */}
+          <span className="text-sm text-cyber-text">
+            <FormattedMessage defaultMessage="This deployment's subscription has expired and it has been scaled to zero. Your data is still here — renew to start it again." />
+          </span>
+          <Link
+            to={`/account/subscriptions/${deployment.subscription_id}`}
+            className="rounded-sm border border-cyber-primary bg-cyber-primary/20 px-4 py-1.5 text-sm font-bold uppercase text-cyber-primary hover:bg-cyber-primary/30 hover:shadow-neon"
+          >
+            <FormattedMessage defaultMessage="Renew" />
+          </Link>
+        </div>
+      )}
+
+      {lifecycle === "deploying" && (
+        <div className="flex flex-wrap items-center gap-3 rounded-sm border border-cyber-border bg-cyber-panel px-4 py-3">
+          <Spinner width={16} height={16} />
+          <span className="text-sm text-cyber-text">
+            <FormattedMessage defaultMessage="Setting up — this usually takes a minute. The endpoint appears once it is running." />
+          </span>
+        </div>
+      )}
+
+      {lifecycle === "error" && deployment.status_message && (
+        <div className="rounded-sm border border-cyber-danger/50 bg-cyber-danger/10 px-4 py-3 text-sm text-cyber-text">
+          {deployment.status_message}
         </div>
       )}
 
@@ -592,7 +750,10 @@ export function AccountAppDeploymentPage() {
             </>
           )}
 
-          {deployment.status_message && (
+          {/* The error banner above already carries this message, so the row
+              would repeat it verbatim. Every other state keeps it — it is
+              detail there, not the headline. */}
+          {deployment.status_message && lifecycle !== "error" && (
             <>
               <dt className="text-cyber-muted">
                 <FormattedMessage defaultMessage="Status detail" />
@@ -633,85 +794,103 @@ export function AccountAppDeploymentPage() {
         </dl>
       </SectionCard>
 
-      {/* Config + rename */}
+      {/* Config + rename. Shown in every state — the values are worth reading
+          even when they cannot be changed — but only saveable once there is a
+          deployment to apply them to. */}
       {app && (
         <SectionCard title={<FormattedMessage defaultMessage="Configure" />}>
           <ConfigEditor
             key={`${deployment.id}-${deployment.name}-${deployment.custom_domain ?? ""}`}
             app={app}
             deployment={deployment}
+            readOnly={!can.configEditable}
             onSaved={setDeployment}
             onError={(m) => setError(m || undefined)}
           />
         </SectionCard>
       )}
 
-      {/* Resize */}
-      <SectionCard title={<FormattedMessage defaultMessage="Size" />}>
-        <UpgradeSection
-          // Remount when the size changes so the selector re-bases off the new
-          // multiplier instead of offering a size that is no longer an upgrade.
-          key={`${deployment.id}-${deployment.resource_multiplier}`}
-          deployment={deployment}
-          onUpgraded={() =>
-            reload().catch((e) => e instanceof Error && setError(e.message))
-          }
-        />
-      </SectionCard>
+      {/* Resize. Hidden unless there is a paid period to prorate against —
+          the API answers 400 otherwise, and quoting against a period nobody
+          bought was the second half of web#54. */}
+      {can.size && (
+        <SectionCard title={<FormattedMessage defaultMessage="Size" />}>
+          <UpgradeSection
+            // Remount when the size changes so the selector re-bases off the new
+            // multiplier instead of offering a size that is no longer an upgrade.
+            key={`${deployment.id}-${deployment.resource_multiplier}`}
+            deployment={deployment}
+            onUpgraded={() =>
+              reload().catch((e) => e instanceof Error && setError(e.message))
+            }
+          />
+        </SectionCard>
+      )}
 
       {/* Lifecycle */}
-      <SectionCard title={<FormattedMessage defaultMessage="Manage" />}>
-        <div className="flex flex-wrap items-center gap-2">
-          {isRunning && (
-            <AsyncButton
-              onClick={() =>
-                act(() => login.api.stopAppDeployment(deployment.id))
-              }
-            >
-              <FormattedMessage defaultMessage="Stop" />
-            </AsyncButton>
-          )}
-          {isStopped && (
-            <AsyncButton
-              className="bg-cyber-primary/20 border-cyber-primary text-cyber-primary hover:bg-cyber-primary/30 hover:shadow-neon"
-              onClick={() =>
-                act(() => login.api.startAppDeployment(deployment.id))
-              }
-            >
-              <FormattedMessage defaultMessage="Start" />
-            </AsyncButton>
-          )}
-
-          <div className="ml-auto flex items-center gap-2">
-            {confirmDelete ? (
-              <>
-                <span className="text-xs text-cyber-muted">
-                  <FormattedMessage defaultMessage="Delete permanently?" />
-                </span>
-                <AsyncButton onClick={async () => setConfirmDelete(false)}>
-                  <FormattedMessage defaultMessage="Cancel" />
-                </AsyncButton>
-                <AsyncButton
-                  className="!bg-cyber-danger/15 !border-cyber-danger !text-cyber-danger hover:!bg-cyber-danger/25"
-                  onClick={onDelete}
-                >
-                  <FormattedMessage defaultMessage="Confirm delete" />
-                </AsyncButton>
-              </>
-            ) : (
+      {(can.stop || can.start || can.delete) && (
+        <SectionCard title={<FormattedMessage defaultMessage="Manage" />}>
+          <div className="flex flex-wrap items-center gap-2">
+            {can.stop && (
               <AsyncButton
-                className="!bg-cyber-danger/15 !border-cyber-danger !text-cyber-danger hover:!bg-cyber-danger/25"
-                onClick={async () => setConfirmDelete(true)}
+                onClick={() =>
+                  act(() => login.api.stopAppDeployment(deployment.id))
+                }
               >
-                <FormattedMessage defaultMessage="Delete" />
+                <FormattedMessage defaultMessage="Stop" />
               </AsyncButton>
             )}
+            {can.start && (
+              <AsyncButton
+                className="bg-cyber-primary/20 border-cyber-primary text-cyber-primary hover:bg-cyber-primary/30 hover:shadow-neon"
+                onClick={() =>
+                  act(() => login.api.startAppDeployment(deployment.id))
+                }
+              >
+                <FormattedMessage defaultMessage="Start" />
+              </AsyncButton>
+            )}
+
+            {/* Delete stays available in every state but `deleting`: someone who
+              ordered by mistake and never paid must be able to remove it
+              without paying first, and an expired one without renewing. */}
+            {can.delete && (
+              <div className="ml-auto flex items-center gap-2">
+                {confirmDelete ? (
+                  <>
+                    <span className="text-xs text-cyber-muted">
+                      <FormattedMessage defaultMessage="Delete permanently?" />
+                    </span>
+                    <AsyncButton onClick={async () => setConfirmDelete(false)}>
+                      <FormattedMessage defaultMessage="Cancel" />
+                    </AsyncButton>
+                    <AsyncButton
+                      className="!bg-cyber-danger/15 !border-cyber-danger !text-cyber-danger hover:!bg-cyber-danger/25"
+                      onClick={onDelete}
+                    >
+                      <FormattedMessage defaultMessage="Confirm delete" />
+                    </AsyncButton>
+                  </>
+                ) : (
+                  <AsyncButton
+                    className="!bg-cyber-danger/15 !border-cyber-danger !text-cyber-danger hover:!bg-cyber-danger/25"
+                    onClick={async () => setConfirmDelete(true)}
+                  >
+                    <FormattedMessage defaultMessage="Delete" />
+                  </AsyncButton>
+                )}
+              </div>
+            )}
           </div>
-        </div>
-        <p className="m-0 mt-3 text-xs text-cyber-muted">
-          <FormattedMessage defaultMessage="Stopping scales the app to zero and retains its data. Deleting stops billing and permanently removes the deployment and its volumes." />
-        </p>
-      </SectionCard>
+          <p className="m-0 mt-3 text-xs text-cyber-muted">
+            {can.stop || can.start ? (
+              <FormattedMessage defaultMessage="Stopping scales the app to zero and retains its data. Deleting stops billing and permanently removes the deployment and its volumes." />
+            ) : (
+              <FormattedMessage defaultMessage="Deleting stops billing and permanently removes the deployment and its volumes." />
+            )}
+          </p>
+        </SectionCard>
+      )}
     </div>
   );
 }

--- a/src/utils/app-deployment.ts
+++ b/src/utils/app-deployment.ts
@@ -1,0 +1,80 @@
+import { AppDeployment } from "../api";
+
+/**
+ * Where a deployment is in its life, as one value.
+ *
+ * The page used to gate its sections on `status` alone, which cannot express
+ * "never paid for": the operator writes a never-paid deployment back as
+ * `stopped` with prose in `status_message`, so after the first reconcile the
+ * payment prompt disappeared, the resize form quoted pro-rata against a period
+ * nobody had bought, and a **Start** button appeared whose request the API's
+ * billing gate refuses (`LNVPS/web#54`). `billing_state` (`LNVPS/api#253`) is
+ * the missing half.
+ */
+export type DeploymentLifecycle =
+  | "deleting"
+  | "unpaid"
+  | "expired"
+  | "error"
+  | "deploying"
+  | "running"
+  | "stopped";
+
+export function deploymentLifecycle(d: AppDeployment): DeploymentLifecycle {
+  // Deletion outranks everything else: it is already happening, and what the
+  // subscription says no longer changes what the customer can do about it.
+  if (d.status === "deleting") return "deleting";
+
+  // Billing outranks operator status — the whole point of api#253. Both of
+  // these can arrive on a deployment the operator reports as `stopped`.
+  if (d.billing_state === "unpaid") return "unpaid";
+  if (d.billing_state === "expired") return "expired";
+
+  // Absent or null `billing_state` means the subscription could not be
+  // resolved, which is an operational fault and not a billing verdict. Fall
+  // through to the operator's view rather than asking a paying customer to pay
+  // again — and note this is also what an API older than #253 produces, where
+  // the bug above is simply not fixable.
+  if (d.status === "error") return "error";
+  if (d.status === "running") return "running";
+  if (d.status === "pending") return "deploying";
+
+  // Asked to run and not running yet: the window between a payment landing and
+  // the operator reporting `running`. This is the case that used to render as
+  // a stopped app with a Start button.
+  if (d.desired_state === "running") return "deploying";
+
+  return "stopped";
+}
+
+/** Sections the customer can act on, per lifecycle state. */
+export interface DeploymentPermissions {
+  /** Resize. Hidden wherever there is no paid period to prorate against. */
+  size: boolean;
+  stop: boolean;
+  start: boolean;
+  /**
+   * Delete is available in every state except one already deleting: someone
+   * who ordered by mistake must be able to remove it without paying first, and
+   * an expired deployment must be removable without renewing it first.
+   */
+  delete: boolean;
+  /** Whether the config form can be saved, as opposed to shown read-only. */
+  configEditable: boolean;
+}
+
+export function deploymentPermissions(
+  lifecycle: DeploymentLifecycle,
+): DeploymentPermissions {
+  return {
+    size: lifecycle === "running" || lifecycle === "stopped",
+    stop: lifecycle === "running",
+    start: lifecycle === "stopped",
+    delete: lifecycle !== "deleting",
+    configEditable:
+      lifecycle === "deploying" ||
+      lifecycle === "running" ||
+      lifecycle === "stopped" ||
+      lifecycle === "error",
+  };
+}


### PR DESCRIPTION
Closes #54.

> *"on the web UI i still see upgrade/stop/delete sections even for a app that isnt started yet or deployed or paid, we should have correctly displayed that the app needs payment → deploying → running"* — @v0l

The page gated on `status` alone, which cannot express "never paid for". The operator writes a never-paid deployment back as `stopped` with prose in `status_message`, so after its **first reconcile** the payment prompt disappeared, the resize form quoted pro-rata against a period nobody had bought, and a **Start** button appeared whose request the billing gate refuses. `billing_state` (LNVPS/api#253) is the missing half.

![unpaid deployment](https://apex-strata.communities.buzz.xyz/media/b7f821904d488d2f3e7974c34686570393f766d482a1b4c2c3806002a1fe8f37.png)

## One derived value

`deploymentLifecycle()` (`src/utils/app-deployment.ts`) folds `billing_state`, `status` and `desired_state` into one state; the pill, the banner and every section gate read it, so the header and the sections underneath cannot disagree.

| state | banner | config | Size | Stop/Start | Delete |
|---|---|---|---|---|---|
| `unpaid` | Pay to activate | read-only | – | – | ✓ |
| `expired` | Renew, data retained | read-only | – | – | ✓ |
| `deploying` | Setting up… | editable | – | – | ✓ |
| `running` | – | editable | ✓ | Stop | ✓ |
| `stopped` | – | editable | ✓ | Start | ✓ |
| `error` | `status_message` | editable | – | – | ✓ |
| `deleting` | – | read-only | – | – | – |

Precedence is `deleting` → billing → operator status. Billing **has** to outrank status, or the original bug returns.

## Before / after, measured

Headless Chrome, signed in, against a stub serving one deployment per state — nine fixtures, including both routes into `deploying` and a null `billing_state`.

| fixture | `bacf621` | this branch |
|---|---|---|
| unpaid, operator already wrote `stopped` | `STOPPED` · no banner · Size · **Start** | `NEEDS PAYMENT` · pay banner · no Size · no Start |
| expired | `STOPPED` · no banner · Size · **Start** | `EXPIRED` · renew banner · no Size · no Start |
| deploying (`pending`) | `PENDING` · pay banner | `DEPLOYING` · setting-up banner · progress at step 2 |
| deploying (`desired=running`) | `STOPPED` · **Start** · Size | `DEPLOYING` · setting-up banner · progress at step 2 |
| running | `RUNNING` · Size · Stop | unchanged, plus progress at step 3 |
| stopped | `STOPPED` · Size · Start | unchanged |
| error | `ERROR` · message in the detail list | message promoted to a banner, Size hidden |
| deleting | `DELETING` · Size · **Delete** | no Size, no Manage |
| `billing_state: null` | `STOPPED` · Size · Start | unchanged — deliberately |

That last row is the contract: null means the subscription could not be resolved, which is an operational fault and not a billing verdict, so it falls through to the operator's view rather than asking a paying customer to pay again. It is also how an API older than #253 behaves, where this bug is not fixable at all.

## Three calls, all cheap to reverse

1. **Delete is available in every state but `deleting`.** Someone who ordered by mistake and never paid must be able to remove it without paying first; an expired one without renewing.
2. **Expired says the data is still there.** True — the operator keeps the volumes — and load-bearing: a customer who thinks their data is gone has no reason to renew.
3. **The progress indicator is only drawn on the path it describes.** Payment → Deploying → Running with the current step marked; stopped, expired, errored and deleting are not points along it, and "2 of 3" on a deployment the customer stopped on purpose says nothing true. Those show the pill alone.

Config is shown **read-only rather than hidden** where it cannot be saved — the settings are worth reading before paying, and a Save the API would refuse is not. `ConfigInput` grew an optional `disabled`.

## Not in this PR

`/account/apps` still labels deployments from `status` alone, so an unpaid one reads "Stopped" in the list and "Needs payment" on its page. Same helper would fix it; #54 scopes to the deployment page, so I left the list alone rather than widen the diff. Say the word.

## Checks

`bunx tsc --noEmit` clean, `bun run build` exit 0, `prettier --check` passes on every file touched (`src/api.ts` is additions-only — it fails `--check` on `main` and I did not reformat it). Six new strings, English-only until the next translate pass; `Running`, `Stopped`, `Expired`, `Deleting`, `Error`, `Payment` and `Renew` reuse existing keys. Commit unsigned (`--no-gpg-sign`): no pinentry TTY.
