### PR TITLE
feat(apps): poll deployments so the page follows the lifecycle

### DIFF
--- a/src/pages/account-app-deployment.tsx
+++ b/src/pages/account-app-deployment.tsx
@@ -514,6 +514,28 @@ export function AccountAppDeploymentPage() {
 
   useEffect(() => {
     reload().catch((e) => e instanceof Error && setError(e.message));
+
+    // The lifecycle moves on its own — a payment lands, the operator
+    // provisions, the pod comes up — and none of it is a click on this page
+    // (`LNVPS/web#71`). Refetching the deployment lets `deploymentLifecycle`
+    // re-derive, so the banner, the pill and the section gates all follow.
+    // Same 5s interval as the VM page (`vm.tsx:108-110`).
+    //
+    // Only the deployment: the catalog app it renders alongside does not
+    // change while the page is open.
+    //
+    // Poll failures are dropped rather than shown. This runs every 5s against
+    // a page the customer is reading; one dropped request should not paint an
+    // error over data that is still on screen and still correct, and the next
+    // tick recovers. The initial load above still surfaces its failure.
+    const t = setInterval(() => {
+      if (!login?.api || !Number.isFinite(deploymentId)) return;
+      login.api
+        .getAppDeployment(deploymentId)
+        .then(setDeployment)
+        .catch(() => {});
+    }, 5_000);
+    return () => clearInterval(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [login?.api, deploymentId]);
 

--- a/src/pages/account-apps.tsx
+++ b/src/pages/account-apps.tsx
@@ -224,14 +224,34 @@ export function AccountAppsPage() {
 
   useEffect(() => {
     if (!login?.api) return;
-    login.api
+    const api = login.api;
+    // The catalog does not change while the page is open; only the
+    // deployments do.
+    api
       .listApps()
       .then(setApps)
       .catch((e) => e instanceof Error && setError(e.message));
-    login.api
+    api
       .listAppDeployments()
       .then(setDeployments)
       .catch(() => setDeployments([]));
+
+    // A deployment moves through payment → deploying → running without the
+    // customer doing anything, and the row label is derived from what the API
+    // last said (`LNVPS/web#71`). Same 5s interval the VM list uses
+    // (`account.tsx:32`).
+    //
+    // A failed poll keeps the rows already on screen rather than blanking them
+    // to `[]` as the first load does: an empty list means "you have no apps",
+    // which is a lie to tell someone over one dropped request. The next tick
+    // recovers.
+    const t = setInterval(() => {
+      api
+        .listAppDeployments()
+        .then(setDeployments)
+        .catch(() => {});
+    }, 5_000);
+    return () => clearInterval(t);
   }, [login?.api]);
 
   const appById = new Map((apps ?? []).map((a) => [a.id, a]));


### PR DESCRIPTION
Closes #71.

A deployment moves through payment → deploying → running without the customer touching anything, and both surfaces rendered whatever the API said when the page loaded. Paying a subscription in another tab left **Needs payment** on screen until a manual reload.

A 5s `setInterval`, cleared on unmount, on each surface — the same shape as the two that already exist for VMs (`vm.tsx:108-110`, `account.tsx:32`):

- `account-app-deployment.tsx` refetches the deployment. Not the catalog app alongside it, which does not change while the page is open.
- `account-apps.tsx` refetches the deployment list. Not `listApps()`, same reason.

Both feed `deploymentLifecycle()`, so the banner, the pill and the section gates re-derive together — polling the raw `status` would put back exactly what #69/#70 removed.

**Poll failures are dropped, deliberately, in two places.** This runs every five seconds against a page someone is reading: one dropped request should not paint an error over data that is still on screen, and the next tick recovers. On the list it also must not fall back to `[]` the way the initial load does — an empty list reads as "you have no apps", a worse lie than a slightly stale row. The initial load still surfaces its own failure on both pages.

Known and accepted: a poll landing between a Stop/Start click and the operator's write-back can briefly show the old state, so the button appears to flip back before settling. Inherent to polling, self-corrects within one tick; the VM page has behaved this way since it shipped.

## Checks

Verified in headless Chrome against a stub that can flip a fixture mid-session:

```
/account/apps/deployments/3  DEPLOYING → RUNNING within 7s, same document
/account/apps  row 1         NEEDS PAYMENT → RUNNING within 7s, same document
navigate away to /           0 deployment requests in the next 7s
```

The "same document" checks read a marker set on `window` before the flip, so a reload would fail them rather than pass for the wrong reason. On `0b56b69` both labels stay stale, which is the bug.

`bunx tsc --noEmit` clean and `bun run build` exit 0, both re-run at `92c2b99`. `prettier --check` passes on both files. No new strings, so no locale work. Commit unsigned (`--no-gpg-sign`): no pinentry TTY here.

Originating channel: `lnvps` (`f5894ea9-44c7-56fb-bd9b-6e3e671e4bc1`).
