### PR TITLE
fix(deps): move js-yaml from override-only to a real dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -57,7 +57,6 @@
   "overrides": {
     "@babel/runtime": "^7.26.10",
     "glob": "^10.5.0",
-    "js-yaml": "^4.1.1",
     "lodash": "^4.17.23",
     "minimatch": "^9.0.7",
     "react": "^19.1.0",

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "classnames": "^2.5.1",
         "dns-over-http-resolver": "^3.0.16",
         "iso-3166-1": "^2.1.1",
+        "js-yaml": "^4.1.1",
         "marked": "^15.0.7",
         "qr-code-styling": "^1.8.4",
         "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "classnames": "^2.5.1",
     "dns-over-http-resolver": "^3.0.16",
     "iso-3166-1": "^2.1.1",
+    "js-yaml": "^4.1.1",
     "marked": "^15.0.7",
     "qr-code-styling": "^1.8.4",
     "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "@babel/runtime": "^7.26.10",
     "minimatch": "^9.0.7",
     "glob": "^10.5.0",
-    "js-yaml": "^4.1.1",
     "lodash": "^4.17.23",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"


### PR DESCRIPTION
From the lnvps channel — prod down, `error: Cannot find package 'js-yaml' from '/app/dist/server/entry-server.js'`. Root cause per Alejandra: `app-compose.ts:1` imports `js-yaml` directly, but it only reached `node_modules` via eslint's dev-only transitive edge plus the `overrides` version pin — never a real entry in `dependencies`. The Dockerfile runner stage installs `--production`, so it was never there.

Fix is the two-line diff: `js-yaml` moved into `dependencies` at the version already pinned by `overrides` (`^4.1.1`, matching what was already resolved), `bun.lock` regenerated. No other package moves.

Verified against the real production install this time, not a full local one:

- `bun install --frozen-lockfile --production` against unmodified `main`: 103 packages, no `js-yaml`. Same command against this branch: 105 packages, `js-yaml@4.1.1` present.
- Built the actual `Dockerfile` both ways. Unmodified `main`'s image crashes on boot with the identical message and `Bun v1.3.14 (Linux x64 baseline)` banner Kieran posted. This branch's image starts and serves 200 with the real SSR title on every route that renders the deploy form — `/apps`, `/apps/1`..`/apps/6` (`app.tsx`), and `/account/apps/deployments/7` (`account-app-deployment.tsx`).

`tsc --noEmit` and `bun test` (28 pass) clean at `b6ea238`. `bun run build` clean. `bun run lint` still only the pre-existing `server/prod.ts:13` error, nothing new.

No issue filed for this one — diagnosed directly in-channel.
