### PR TITLE
fix(build): retry the sitemap's app-catalog fetch

### DIFF
--- a/server/gen-sitemap.test.ts
+++ b/server/gen-sitemap.test.ts
@@ -93,13 +93,10 @@ describe("withRetry", () => {
   test("stops at the attempt limit and throws the last error", async () => {
     let calls = 0;
     await expect(
-      withRetry(
-        async () => {
-          calls++;
-          throw new Error(`fail ${calls}`);
-        },
-        { attempts: 3, delayMs: 0 },
-      ),
+      withRetry(async () => {
+        calls++;
+        throw new Error(`fail ${calls}`);
+      }, { delayMs: 0 }),
     ).rejects.toThrow("fail 3");
     expect(calls).toBe(3);
   });

--- a/server/gen-sitemap.test.ts
+++ b/server/gen-sitemap.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildSitemapXml,
   STATIC_ENTRIES,
+  withRetry,
   type ArchiveEvent,
 } from "./gen-sitemap";
 
@@ -61,5 +62,45 @@ describe("buildSitemapXml", () => {
 
   test("lastmod is the published_at date", () => {
     expect(xml).toContain("<lastmod>2026-07-06</lastmod>");
+  });
+});
+
+describe("withRetry", () => {
+  test("returns the first success without retrying", async () => {
+    let calls = 0;
+    const result = await withRetry(async () => {
+      calls++;
+      return "ok";
+    });
+    expect(result).toBe("ok");
+    expect(calls).toBe(1);
+  });
+
+  test("retries a failure and returns the later success", async () => {
+    let calls = 0;
+    const result = await withRetry(
+      async () => {
+        calls++;
+        if (calls < 3) throw new Error("transient");
+        return "ok";
+      },
+      { delayMs: 0 },
+    );
+    expect(result).toBe("ok");
+    expect(calls).toBe(3);
+  });
+
+  test("stops at the attempt limit and throws the last error", async () => {
+    let calls = 0;
+    await expect(
+      withRetry(
+        async () => {
+          calls++;
+          throw new Error(`fail ${calls}`);
+        },
+        { attempts: 3, delayMs: 0 },
+      ),
+    ).rejects.toThrow("fail 3");
+    expect(calls).toBe(3);
   });
 });

--- a/server/gen-sitemap.ts
+++ b/server/gen-sitemap.ts
@@ -163,11 +163,31 @@ async function fetchAppIds(): Promise<Array<number>> {
   return ids;
 }
 
+/**
+ * Retry a flaky call rather than fail the build on the first attempt. The
+ * scrubbing path in front of the API drops some SYN packets under concurrent
+ * connection bursts, so a timeout here is often gone on the next try (the
+ * Docker registry login in `build-deploy.yml` retries the same flake).
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  { attempts = 3, delayMs = 2000 }: { attempts?: number; delayMs?: number } = {},
+): Promise<T> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= attempts) throw err;
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+}
+
 if (import.meta.main) {
   const archive = JSON.parse(
     readFileSync(ARCHIVE_PATH, "utf-8"),
   ) as Array<ArchiveEvent>;
-  const appIds = await fetchAppIds();
+  const appIds = await withRetry(fetchAppIds);
   const xml = buildSitemapXml(archive, appIds);
 
   for (const dir of OUT_DIRS) {

--- a/server/gen-sitemap.ts
+++ b/server/gen-sitemap.ts
@@ -163,6 +163,8 @@ async function fetchAppIds(): Promise<Array<number>> {
   return ids;
 }
 
+const RETRY_ATTEMPTS = 3;
+
 /**
  * Retry a flaky call rather than fail the build on the first attempt. The
  * scrubbing path in front of the API drops some SYN packets under concurrent
@@ -171,13 +173,17 @@ async function fetchAppIds(): Promise<Array<number>> {
  */
 export async function withRetry<T>(
   fn: () => Promise<T>,
-  { attempts = 3, delayMs = 2000 }: { attempts?: number; delayMs?: number } = {},
+  { delayMs = 2000 }: { delayMs?: number } = {},
 ): Promise<T> {
   for (let attempt = 1; ; attempt++) {
     try {
       return await fn();
     } catch (err) {
-      if (attempt >= attempts) throw err;
+      if (attempt >= RETRY_ATTEMPTS) throw err;
+      // Otherwise identical to a fast first-try success in the build log.
+      console.warn(
+        `retrying after a failed attempt (${attempt}/${RETRY_ATTEMPTS}): ${err}`,
+      );
       await new Promise((r) => setTimeout(r, delayMs));
     }
   }


### PR DESCRIPTION
From Goran's web#86 review — dropping the UAT step halves exposure to the sitemap flake, it doesn't remove it. `fetchAppIds` (`gen-sitemap.ts:157`) still has one `fetch` at a 15s timeout with no retry, and its failure aborts `bun run sitemap` and the whole builder stage — the remaining `:latest` build can still die on the same AVS/GSL SYN-drop flake that took down the two builds referenced in that thread.

Added `withRetry` (3 attempts, 2s apart, exported for testing) and wrapped `fetchAppIds` with it — same shape as the `nick-fields/retry` already around the Docker registry login in `build-deploy.yml`. Kept it as retry rather than a fallback: the file's own top comment says a build with no catalog should fail rather than quietly publish a sitemap missing product pages, and a transient blip degrading to that silently would go against that.

Verified: `withRetry` unit-tested for first-try success, recovery after failures, and exhausting attempts (3 new tests, `tsc`/`bun test` clean at `e60e362`, 31 pass). Pointed `SITEMAP_APPS_URL` at a refused connection and confirmed it makes exactly 3 real attempts (~4s wall time) before failing, so the call site is actually wired up, not just the helper in isolation. `bun run build` clean.
