### PR TITLE
fix(api): only set content-type header when a body is sent

### DIFF
--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { LNVpsApi } from "./api";
+
+describe("LNVpsApi#req content-type", () => {
+  const realFetch = globalThis.fetch;
+  let lastInit: RequestInit | undefined;
+
+  beforeEach(() => {
+    lastInit = undefined;
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      lastInit = init;
+      return new Response(JSON.stringify({ data: {} }), { status: 200 });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  test("omits content-type when no body is sent", async () => {
+    const api = new LNVpsApi("http://test", undefined, undefined, "token");
+    // reinstallVm with no image_id sends no body (re-install with current image)
+    await api.reinstallVm(1);
+
+    expect(lastInit?.body).toBeUndefined();
+    const headers = lastInit?.headers as Record<string, string>;
+    expect(headers["content-type"]).toBeUndefined();
+  });
+
+  test("sets content-type when a body is sent", async () => {
+    const api = new LNVpsApi("http://test", undefined, undefined, "token");
+    await api.reinstallVm(1, 5);
+
+    expect(lastInit?.body).toBe(JSON.stringify({ image_id: 5 }));
+    const headers = lastInit?.headers as Record<string, string>;
+    expect(headers["content-type"]).toBe("application/json");
+  });
+});

--- a/src/api.ts
+++ b/src/api.ts
@@ -2035,7 +2035,7 @@ export class LNVpsApi {
         body: body ? JSON.stringify(body) : undefined,
         headers: {
           accept: "application/json",
-          "content-type": "application/json",
+          ...(body ? { "content-type": "application/json" } : {}),
           authorization: (await this.#auth(u, method)) ?? "",
         },
         signal: controller.signal,


### PR DESCRIPTION
Closes #90.

`#req` always set `content-type: application/json`, even when `body` was `undefined` — the server's `Option<Json<ReinstallRequest>>` extractor then tries to parse zero bytes as JSON and errors instead of treating it as `None`. Only the reinstall-with-no-image-change path hit this (no other caller sends an empty body), but the fix is in the shared request helper.

Header is now only set when a body is actually sent. Added a test exercising `reinstallVm` both ways (with and without `image_id`) against a mocked `fetch`, confirmed it fails on the old code and passes on the new.

`bun test`, `bun run typecheck`, `bun run lint`, and `bun run build` all pass on this branch.
