### PR TITLE
Custom VM orders: choose IPv4/IPv6 count

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -247,6 +247,10 @@ export interface VmCustomTemplateParams {
   min_cpu: number;
   min_memory: number;
   max_memory: number;
+  min_ip4: number;
+  max_ip4: number;
+  min_ip6: number;
+  max_ip6: number;
   disks: Array<VmCustomTemplateDiskParams>;
 }
 
@@ -264,6 +268,8 @@ export interface VmCustomTemplateRequest {
   disk: number;
   disk_type: DiskType;
   disk_interface: DiskInterface;
+  ip4_count?: number;
+  ip6_count?: number;
 }
 
 export interface VmCustomPrice {
@@ -290,6 +296,8 @@ export interface VmTemplate {
   disk_size: number;
   disk_type: DiskType;
   disk_interface: DiskInterface;
+  ip4_count: number;
+  ip6_count: number;
   cost_plan: VmCostPlan;
   region: VmHostRegion;
 }

--- a/src/components/vps-custom.tsx
+++ b/src/components/vps-custom.tsx
@@ -233,6 +233,8 @@ export function VpsCustomOrder({
   const [disk, setDisk] = useState(
     Math.floor((preferredDisk(params.disks)?.min_disk ?? GiB) / GiB),
   );
+  const [ip4, setIp4] = useState(params.min_ip4 ?? 1);
+  const [ip6, setIp6] = useState(params.min_ip6 ?? 0);
 
   const [price, setPrice] = useState<VmCustomPrice>();
 
@@ -261,6 +263,8 @@ export function VpsCustomOrder({
       setDiskType(disk0);
       setRam(Math.floor((params.min_memory ?? GiB) / GiB));
       setDisk(Math.floor((disk0?.min_disk ?? GiB) / GiB));
+      setIp4(params.min_ip4 ?? 1);
+      setIp6(params.min_ip6 ?? 0);
     }
   }, [params]);
 
@@ -284,11 +288,13 @@ export function VpsCustomOrder({
           disk: disk * GiB,
           disk_type: diskType?.disk_type ?? DiskType.SSD,
           disk_interface: diskType?.disk_interface ?? DiskInterface.PCIe,
+          ip4_count: ip4,
+          ip6_count: ip6,
         })
         .then(setPrice);
     }, 500);
     return () => clearTimeout(t);
-  }, [region, cpu, ram, disk, diskType, params]);
+  }, [region, cpu, ram, disk, diskType, ip4, ip6, params]);
 
   if (templates.length == 0) return;
 
@@ -425,6 +431,26 @@ export function VpsCustomOrder({
             max={Math.floor((diskType?.max_disk ?? 0) / GiB)}
             onChange={setDisk}
           />
+          {params.max_ip4 > params.min_ip4 && (
+            <ResourceSlider
+              label={<FormattedMessage defaultMessage="IPv4" />}
+              unit="IPs"
+              value={ip4}
+              min={params.min_ip4}
+              max={params.max_ip4}
+              onChange={setIp4}
+            />
+          )}
+          {params.max_ip6 > params.min_ip6 && (
+            <ResourceSlider
+              label={<FormattedMessage defaultMessage="IPv6" />}
+              unit="IPs"
+              value={ip6}
+              min={params.min_ip6}
+              max={params.max_ip6}
+              onChange={setIp6}
+            />
+          )}
         </div>
       </div>
 
@@ -432,7 +458,8 @@ export function VpsCustomOrder({
       <div className="flex flex-col gap-3 border-t border-cyber-border bg-cyber-panel-light px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-col gap-0.5">
           <div className="font-mono text-xs text-cyber-muted tabular-nums">
-            {cpu} vCPU · {ram} GB · {disk} {diskUnit} @ {params.region.name}
+            {cpu} vCPU · {ram} GB · {disk} {diskUnit} · {ip4} IPv4
+            {ip6 > 0 && ` + ${ip6} IPv6`} @ {params.region.name}
           </div>
           {price && (
             <div className="text-xl leading-none text-cyber-text-bright">
@@ -451,6 +478,8 @@ export function VpsCustomOrder({
               disk_size: disk * GiB,
               disk_type: diskType?.disk_type ?? DiskType.SSD,
               disk_interface: diskType?.disk_interface ?? DiskInterface.PCIe,
+              ip4_count: ip4,
+              ip6_count: ip6,
               created: new Date().toISOString(),
               region: params.region,
               cost_plan,

--- a/src/components/vps-custom.tsx
+++ b/src/components/vps-custom.tsx
@@ -233,8 +233,8 @@ export function VpsCustomOrder({
   const [disk, setDisk] = useState(
     Math.floor((preferredDisk(params.disks)?.min_disk ?? GiB) / GiB),
   );
-  const [ip4, setIp4] = useState(params.min_ip4 ?? 1);
-  const [ip6, setIp6] = useState(params.min_ip6 ?? 0);
+  const [ip4, setIp4] = useState(params.min_ip4);
+  const [ip6, setIp6] = useState(params.min_ip6);
 
   const [price, setPrice] = useState<VmCustomPrice>();
 
@@ -263,8 +263,8 @@ export function VpsCustomOrder({
       setDiskType(disk0);
       setRam(Math.floor((params.min_memory ?? GiB) / GiB));
       setDisk(Math.floor((disk0?.min_disk ?? GiB) / GiB));
-      setIp4(params.min_ip4 ?? 1);
-      setIp6(params.min_ip6 ?? 0);
+      setIp4(params.min_ip4);
+      setIp6(params.min_ip6);
     }
   }, [params]);
 

--- a/src/components/vps-resources.tsx
+++ b/src/components/vps-resources.tsx
@@ -41,29 +41,27 @@ export default function VpsResources({ vm }: { vm: VmInstance | VmTemplate }) {
   const cpuMfg = formatCpuMfg(template?.cpu_mfg);
   const cpuArch = formatCpuArch(template?.cpu_arch);
   const cpuInfo = [cpuMfg, cpuArch].filter(Boolean).join(" ");
-  const ip4Count = template?.ip4_count;
-  const ip6Count = template?.ip6_count;
   return (
     <>
       <div className="text-xs text-cyber-muted">
         {template?.cpu} vCPU{cpuInfo && ` (${cpuInfo})`},{" "}
         <BytesSize value={template?.memory ?? 0} /> RAM,{" "}
         <BytesSize value={template?.disk_size ?? 0} /> {diskType?.toUpperCase()}
-        {ip4Count !== undefined && ip4Count > 1 && (
+        {(template?.ip4_count ?? 0) > 1 && (
           <>
             ,{" "}
             <FormattedMessage
               defaultMessage="{count} IPv4"
-              values={{ count: ip4Count }}
+              values={{ count: template?.ip4_count ?? 0 }}
             />
           </>
         )}
-        {ip6Count !== undefined && ip6Count > 0 && (
+        {(template?.ip6_count ?? 0) > 0 && (
           <>
             ,{" "}
             <FormattedMessage
               defaultMessage="{count} IPv6"
-              values={{ count: ip6Count }}
+              values={{ count: template?.ip6_count ?? 0 }}
             />
           </>
         )}

--- a/src/components/vps-resources.tsx
+++ b/src/components/vps-resources.tsx
@@ -41,12 +41,32 @@ export default function VpsResources({ vm }: { vm: VmInstance | VmTemplate }) {
   const cpuMfg = formatCpuMfg(template?.cpu_mfg);
   const cpuArch = formatCpuArch(template?.cpu_arch);
   const cpuInfo = [cpuMfg, cpuArch].filter(Boolean).join(" ");
+  const ip4Count = template?.ip4_count;
+  const ip6Count = template?.ip6_count;
   return (
     <>
       <div className="text-xs text-cyber-muted">
         {template?.cpu} vCPU{cpuInfo && ` (${cpuInfo})`},{" "}
         <BytesSize value={template?.memory ?? 0} /> RAM,{" "}
         <BytesSize value={template?.disk_size ?? 0} /> {diskType?.toUpperCase()}
+        {ip4Count !== undefined && ip4Count > 1 && (
+          <>
+            ,{" "}
+            <FormattedMessage
+              defaultMessage="{count} IPv4"
+              values={{ count: ip4Count }}
+            />
+          </>
+        )}
+        {ip6Count !== undefined && ip6Count > 0 && (
+          <>
+            ,{" "}
+            <FormattedMessage
+              defaultMessage="{count} IPv6"
+              values={{ count: ip6Count }}
+            />
+          </>
+        )}
         {region && (
           <>
             ,{" "}

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -62,6 +62,9 @@
   "/QkDVJ": {
     "defaultMessage": "محفظة إن دبليو سي"
   },
+  "/hnclP": {
+    "defaultMessage": "{count} IPv4"
+  },
   "/kXbXW": {
     "defaultMessage": "ما الذي يمكنك إنشاؤه؟"
   },
@@ -551,6 +554,9 @@
   "BZF5HJ": {
     "defaultMessage": "نطاقات نوستر"
   },
+  "BnPEWz": {
+    "defaultMessage": "IPv4"
+  },
   "BnoVvl": {
     "defaultMessage": "شروط الخدمة الخاصة بـ LNVPS. يرجى قراءة سياسات الاستخدام والإرشادات الخاصة بالاستخدام المقبول وشروط الخدمة."
   },
@@ -856,6 +862,9 @@
   },
   "J+pWCM": {
     "defaultMessage": "New size"
+  },
+  "J7750w": {
+    "defaultMessage": "{count} IPv6"
   },
   "JAJV1y": {
     "defaultMessage": "يتم تعيينه بمجرد بدء التشغيل."
@@ -1867,6 +1876,9 @@
   },
   "jwt9EL": {
     "defaultMessage": "فشل تسجيل الدخول بمفتاح المرور"
+  },
+  "jyXJcj": {
+    "defaultMessage": "IPv6"
   },
   "jzU8se": {
     "defaultMessage": "Deploy Route96 — {price}/month"

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -62,6 +62,9 @@
   "/QkDVJ": {
     "defaultMessage": "NWC-Wallet"
   },
+  "/hnclP": {
+    "defaultMessage": "{count} IPv4"
+  },
   "/kXbXW": {
     "defaultMessage": "Was Sie erstellen können."
   },
@@ -551,6 +554,9 @@
   "BZF5HJ": {
     "defaultMessage": "Nostr-Domänen"
   },
+  "BnPEWz": {
+    "defaultMessage": "IPv4"
+  },
   "BnoVvl": {
     "defaultMessage": "Nutzungsbedingungen für LNVPS. Bitte lesen Sie unsere Nutzungsrichtlinien, Richtlinien für die zulässige Nutzung und die Servicebedingungen."
   },
@@ -856,6 +862,9 @@
   },
   "J+pWCM": {
     "defaultMessage": "New size"
+  },
+  "J7750w": {
+    "defaultMessage": "{count} IPv6"
   },
   "JAJV1y": {
     "defaultMessage": "Einmal zugewiesen, bleibt es zugewiesen."
@@ -1867,6 +1876,9 @@
   },
   "jwt9EL": {
     "defaultMessage": "Passkey-Anmeldung fehlgeschlagen"
+  },
+  "jyXJcj": {
+    "defaultMessage": "IPv6"
   },
   "jzU8se": {
     "defaultMessage": "Deploy Route96 — {price}/month"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -62,6 +62,9 @@
   "/QkDVJ": {
     "defaultMessage": "NWC Wallet"
   },
+  "/hnclP": {
+    "defaultMessage": "{count} IPv4"
+  },
   "/kXbXW": {
     "defaultMessage": "What you can build"
   },
@@ -551,6 +554,9 @@
   "BZF5HJ": {
     "defaultMessage": "Nostr Domains"
   },
+  "BnPEWz": {
+    "defaultMessage": "IPv4"
+  },
   "BnoVvl": {
     "defaultMessage": "Terms of Service for LNVPS. Read our usage policies, acceptable use guidelines, and service terms."
   },
@@ -856,6 +862,9 @@
   },
   "J+pWCM": {
     "defaultMessage": "New size"
+  },
+  "J7750w": {
+    "defaultMessage": "{count} IPv6"
   },
   "JAJV1y": {
     "defaultMessage": "Assigned once running"
@@ -1867,6 +1876,9 @@
   },
   "jwt9EL": {
     "defaultMessage": "Passkey sign-in failed"
+  },
+  "jyXJcj": {
+    "defaultMessage": "IPv6"
   },
   "jzU8se": {
     "defaultMessage": "Deploy Route96 — {price}/month"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -62,6 +62,9 @@
   "/QkDVJ": {
     "defaultMessage": "Cartera NWC"
   },
+  "/hnclP": {
+    "defaultMessage": "{count} IPv4"
+  },
   "/kXbXW": {
     "defaultMessage": "Qué puedes construir."
   },
@@ -551,6 +554,9 @@
   "BZF5HJ": {
     "defaultMessage": "Dominios Nostr"
   },
+  "BnPEWz": {
+    "defaultMessage": "IPv4"
+  },
   "BnoVvl": {
     "defaultMessage": "Términos de servicio de LNVPS. Consulte nuestras políticas de uso, las directrices para un uso adecuado y los términos del servicio."
   },
@@ -856,6 +862,9 @@
   },
   "J+pWCM": {
     "defaultMessage": "New size"
+  },
+  "J7750w": {
+    "defaultMessage": "{count} IPv6"
   },
   "JAJV1y": {
     "defaultMessage": "Se asigna una vez que se inicia el proceso."
@@ -1867,6 +1876,9 @@
   },
   "jwt9EL": {
     "defaultMessage": "Error al iniciar sesión con la clave de acceso"
+  },
+  "jyXJcj": {
+    "defaultMessage": "IPv6"
   },
   "jzU8se": {
     "defaultMessage": "Deploy Route96 — {price}/month"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -62,6 +62,9 @@
   "/QkDVJ": {
     "defaultMessage": "Portefeuille NWC"
   },
+  "/hnclP": {
+    "defaultMessage": "{count} IPv4"
+  },
   "/kXbXW": {
     "defaultMessage": "Ce que vous pouvez créer."
   },
@@ -551,6 +554,9 @@
   "BZF5HJ": {
     "defaultMessage": "Domaines Nostr"
   },
+  "BnPEWz": {
+    "defaultMessage": "IPv4"
+  },
   "BnoVvl": {
     "defaultMessage": "Conditions d’utilisation de LNVPS. Veuillez consulter nos règles d’utilisation, nos directives concernant l’utilisation acceptable et nos conditions de service."
   },
@@ -856,6 +862,9 @@
   },
   "J+pWCM": {
     "defaultMessage": "New size"
+  },
+  "J7750w": {
+    "defaultMessage": "{count} IPv6"
   },
   "JAJV1y": {
     "defaultMessage": "Attribué une fois l’opération lancée."
@@ -1867,6 +1876,9 @@
   },
   "jwt9EL": {
     "defaultMessage": "Échec de la connexion par clé d'accès"
+  },
+  "jyXJcj": {
+    "defaultMessage": "IPv6"
   },
   "jzU8se": {
     "defaultMessage": "Deploy Route96 — {price}/month"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -62,6 +62,9 @@
   "/QkDVJ": {
     "defaultMessage": "NWCウォレット"
   },
+  "/hnclP": {
+    "defaultMessage": "{count} IPv4"
+  },
   "/kXbXW": {
     "defaultMessage": "何を作ることができますか。"
   },
@@ -551,6 +554,9 @@
   "BZF5HJ": {
     "defaultMessage": "Nostrドメイン"
   },
+  "BnPEWz": {
+    "defaultMessage": "IPv4"
+  },
   "BnoVvl": {
     "defaultMessage": "LNVPSの利用規約。当社の利用ポリシー、適切な利用に関するガイドライン、およびサービス条件をお読みください。"
   },
@@ -856,6 +862,9 @@
   },
   "J+pWCM": {
     "defaultMessage": "New size"
+  },
+  "J7750w": {
+    "defaultMessage": "{count} IPv6"
   },
   "JAJV1y": {
     "defaultMessage": "実行時に一度割り当て"
@@ -1867,6 +1876,9 @@
   },
   "jwt9EL": {
     "defaultMessage": "パスキーでのサインインに失敗しました"
+  },
+  "jyXJcj": {
+    "defaultMessage": "IPv6"
   },
   "jzU8se": {
     "defaultMessage": "Deploy Route96 — {price}/month"

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -62,6 +62,9 @@
   "/QkDVJ": {
     "defaultMessage": "NWC 지갑"
   },
+  "/hnclP": {
+    "defaultMessage": "{count} IPv4"
+  },
   "/kXbXW": {
     "defaultMessage": "무엇을 만들 수 있을까요?"
   },
@@ -551,6 +554,9 @@
   "BZF5HJ": {
     "defaultMessage": "노스트르 도메인"
   },
+  "BnPEWz": {
+    "defaultMessage": "IPv4"
+  },
   "BnoVvl": {
     "defaultMessage": "LNVPS 이용 약관. 당사의 이용 정책, 허용되는 사용 지침 및 서비스 약관을 읽어보세요."
   },
@@ -856,6 +862,9 @@
   },
   "J+pWCM": {
     "defaultMessage": "New size"
+  },
+  "J7750w": {
+    "defaultMessage": "{count} IPv6"
   },
   "JAJV1y": {
     "defaultMessage": "실행 시 한 번 할당됨"
@@ -1867,6 +1876,9 @@
   },
   "jwt9EL": {
     "defaultMessage": "패스키 로그인 실패"
+  },
+  "jyXJcj": {
+    "defaultMessage": "IPv6"
   },
   "jzU8se": {
     "defaultMessage": "Deploy Route96 — {price}/month"

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -62,6 +62,9 @@
   "/QkDVJ": {
     "defaultMessage": "Carteira NWC"
   },
+  "/hnclP": {
+    "defaultMessage": "{count} IPv4"
+  },
   "/kXbXW": {
     "defaultMessage": "O que pode construir."
   },
@@ -551,6 +554,9 @@
   "BZF5HJ": {
     "defaultMessage": "Domínios Nostr"
   },
+  "BnPEWz": {
+    "defaultMessage": "IPv4"
+  },
   "BnoVvl": {
     "defaultMessage": "Termos de Serviço do LNVPS. Leia as nossas políticas de utilização, diretrizes de uso aceitável e termos de serviço."
   },
@@ -856,6 +862,9 @@
   },
   "J+pWCM": {
     "defaultMessage": "New size"
+  },
+  "J7750w": {
+    "defaultMessage": "{count} IPv6"
   },
   "JAJV1y": {
     "defaultMessage": "Atribuído após o início da execução."
@@ -1867,6 +1876,9 @@
   },
   "jwt9EL": {
     "defaultMessage": "Falha ao iniciar sessão com a chave de acesso"
+  },
+  "jyXJcj": {
+    "defaultMessage": "IPv6"
   },
   "jzU8se": {
     "defaultMessage": "Deploy Route96 — {price}/month"

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -62,6 +62,9 @@
   "/QkDVJ": {
     "defaultMessage": "Кошелек NWC"
   },
+  "/hnclP": {
+    "defaultMessage": "{count} IPv4"
+  },
   "/kXbXW": {
     "defaultMessage": "Что вы можете создать."
   },
@@ -551,6 +554,9 @@
   "BZF5HJ": {
     "defaultMessage": "Домены Nostr"
   },
+  "BnPEWz": {
+    "defaultMessage": "IPv4"
+  },
   "BnoVvl": {
     "defaultMessage": "Условия использования сервиса LNVPS. Ознакомьтесь с нашими правилами использования, требованиями к допустимому использованию и условиями предоставления услуг."
   },
@@ -856,6 +862,9 @@
   },
   "J+pWCM": {
     "defaultMessage": "New size"
+  },
+  "J7750w": {
+    "defaultMessage": "{count} IPv6"
   },
   "JAJV1y": {
     "defaultMessage": "Назначается после запуска."
@@ -1867,6 +1876,9 @@
   },
   "jwt9EL": {
     "defaultMessage": "Не удалось войти с ключом доступа"
+  },
+  "jyXJcj": {
+    "defaultMessage": "IPv6"
   },
   "jzU8se": {
     "defaultMessage": "Deploy Route96 — {price}/month"

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -62,6 +62,9 @@
   "/QkDVJ": {
     "defaultMessage": "NWC Cüzdanı"
   },
+  "/hnclP": {
+    "defaultMessage": "{count} IPv4"
+  },
   "/kXbXW": {
     "defaultMessage": "Ne tür şeyler inşa edebilirsiniz?"
   },
@@ -551,6 +554,9 @@
   "BZF5HJ": {
     "defaultMessage": "Nostr Alan Adları"
   },
+  "BnPEWz": {
+    "defaultMessage": "IPv4"
+  },
   "BnoVvl": {
     "defaultMessage": "LNVPS Hizmet Şartları. Kullanım politikalarımızı, kabul edilebilir kullanım yönergelerimizi ve hizmet şartlarımızı okuyun."
   },
@@ -856,6 +862,9 @@
   },
   "J+pWCM": {
     "defaultMessage": "New size"
+  },
+  "J7750w": {
+    "defaultMessage": "{count} IPv6"
   },
   "JAJV1y": {
     "defaultMessage": "Çalıştırıldıktan sonra atanır."
@@ -1867,6 +1876,9 @@
   },
   "jwt9EL": {
     "defaultMessage": "Geçiş anahtarıyla giriş başarısız"
+  },
+  "jyXJcj": {
+    "defaultMessage": "IPv6"
   },
   "jzU8se": {
     "defaultMessage": "Deploy Route96 — {price}/month"

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -62,6 +62,9 @@
   "/QkDVJ": {
     "defaultMessage": "NWC 钱包"
   },
+  "/hnclP": {
+    "defaultMessage": "{count} IPv4"
+  },
   "/kXbXW": {
     "defaultMessage": "你可以构建什么。"
   },
@@ -551,6 +554,9 @@
   "BZF5HJ": {
     "defaultMessage": "Nostr 域名"
   },
+  "BnPEWz": {
+    "defaultMessage": "IPv4"
+  },
   "BnoVvl": {
     "defaultMessage": "LNVPS 服务条款。请阅读我们的使用政策、可接受的使用规范和服务条款。"
   },
@@ -856,6 +862,9 @@
   },
   "J+pWCM": {
     "defaultMessage": "New size"
+  },
+  "J7750w": {
+    "defaultMessage": "{count} IPv6"
   },
   "JAJV1y": {
     "defaultMessage": "启动后自动分配。"
@@ -1867,6 +1876,9 @@
   },
   "jwt9EL": {
     "defaultMessage": "通行密钥登录失败"
+  },
+  "jyXJcj": {
+    "defaultMessage": "IPv6"
   },
   "jzU8se": {
     "defaultMessage": "Deploy Route96 — {price}/month"

--- a/src/pages/order/vm.tsx
+++ b/src/pages/order/vm.tsx
@@ -56,6 +56,8 @@ export default function OrderVmPage({ template }: { template: VmTemplate }) {
               disk_type: template.disk_type,
               disk_interface: template.disk_interface,
               pricing_id: template.pricing_id!,
+              ip4_count: template.ip4_count,
+              ip6_count: template.ip6_count,
             },
             useImage,
             useSshKey,

--- a/src/utils/regions.test.ts
+++ b/src/utils/regions.test.ts
@@ -21,6 +21,10 @@ const dublin: VmCustomTemplateParams = {
   max_cpu: 64,
   min_memory: 1 * GiB,
   max_memory: 128 * GiB,
+  min_ip4: 1,
+  max_ip4: 4,
+  min_ip6: 0,
+  max_ip6: 1,
   disks: [
     {
       min_disk: 100 * GiB,
@@ -45,6 +49,10 @@ const london: VmCustomTemplateParams = {
   max_cpu: 16,
   min_memory: 1 * GiB,
   max_memory: 16 * GiB,
+  min_ip4: 1,
+  max_ip4: 1,
+  min_ip6: 0,
+  max_ip6: 0,
   disks: [
     {
       min_disk: 10 * GiB,

--- a/src/utils/vps-seo.test.ts
+++ b/src/utils/vps-seo.test.ts
@@ -21,6 +21,8 @@ function template(over: Partial<VmTemplate> = {}): VmTemplate {
     disk_size: 160 * GiB,
     disk_type: DiskType.SSD,
     disk_interface: DiskInterface.PCIe,
+    ip4_count: 1,
+    ip6_count: 0,
     cost_plan: {
       id: 16,
       name: "Medium Yearly Discount Cost Plan",


### PR DESCRIPTION
Closes #92.

Depends on api#105 (LNVPS/api#339, not merged yet) — do not merge before that lands, the endpoints don't accept/return these fields until it does.

- `src/api.ts:250-253,271-272,299-300` — `min_ip4`/`max_ip4`/`min_ip6`/`max_ip6` on `VmCustomTemplateParams`, `ip4_count`/`ip6_count` on `VmCustomTemplateRequest` and `VmTemplate`.
- `src/components/vps-custom.tsx` — IPv4/IPv6 sliders next to CPU/memory/storage, same min/max pattern; hidden when a template has no range to offer. Wired into the live price quote and the order spec.
- `src/pages/order/vm.tsx:59-60` — the chosen counts actually reach `orderCustom`, not just the quote.
- `src/components/vps-resources.tsx` — order-review line and VM cards show the count when it's not the boring default (>1 IPv4, any IPv6).
- Locale copy extracted and translated to all 10 languages.

Built against the contract Bojan posted in general — can't verify end to end until api#105 merges.

Known at merge time: api#105 caps `max_ip4`/`max_ip6` at 1 (Proxmox's single-NIC `ipconfig0` can't carry a second address yet, api#343 lifts it), so both sliders stay hidden until that cap is lifted. Confirmed correct behaviour, not a bug — flagged by Goran in general.