### PR TITLE
Translate /blossom-server-hosting into all 10 locales

### DIFF
--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -9,7 +9,7 @@
     "defaultMessage": "صادر"
   },
   "+Bj8tM": {
-    "defaultMessage": "Stopping retains your uploads; only deleting removes them"
+    "defaultMessage": "إيقاف العملية يحافظ على الملفات التي تم تحميلها؛ أما حذفها فيؤدي إلى إزالتها نهائيًا."
   },
   "+EHk4e": {
     "defaultMessage": "نعم. هذا جهازك، لذا قم بتثبيت ما تريد."
@@ -171,7 +171,7 @@
     "defaultMessage": "إنشاء طلب شراء"
   },
   "2lKQfH": {
-    "defaultMessage": "How much can I store?"
+    "defaultMessage": "كم يمكنني تخزين؟"
   },
   "2mZOHz": {
     "defaultMessage": "Quote currency"
@@ -390,7 +390,7 @@
     "defaultMessage": "ادفع الآن."
   },
   "7v5vj0": {
-    "defaultMessage": "Host your own media server — {price} a month"
+    "defaultMessage": "استضِف خادم الوسائط الخاص بك — مقابل {price} شهريًا."
   },
   "7wbySo": {
     "defaultMessage": "أرسل لنا رسالة مباشرة وسيتواصل معك فريق الدعم."
@@ -435,7 +435,7 @@
     "defaultMessage": "حفظ مسار الدفع"
   },
   "8dAKuZ": {
-    "defaultMessage": "Yes — CNAME, and the certificate is issued automatically once DNS resolves."
+    "defaultMessage": "نعم، وهو اسم مستعار (CNAME)، ويتم إصدار الشهادة تلقائيًا بمجرد حل سجلات نظام أسماء النطاقات (DNS)."
   },
   "8ecw1u": {
     "defaultMessage": "مقابض"
@@ -711,7 +711,7 @@
     "defaultMessage": "غير متصل."
   },
   "FZup6q": {
-    "defaultMessage": "Where does it run?"
+    "defaultMessage": "أين يتم تشغيله؟"
   },
   "FazwRl": {
     "defaultMessage": "حاول مرة أخرى."
@@ -837,7 +837,7 @@
     "defaultMessage": "جاهز."
   },
   "IbWc3k": {
-    "defaultMessage": "Dublin, Ireland."
+    "defaultMessage": "دبلن، أيرلندا."
   },
   "Id24hd": {
     "defaultMessage": "الاسم *"
@@ -1071,7 +1071,7 @@
     "defaultMessage": "لم يتم العثور على أي طلب."
   },
   "Pk14hW": {
-    "defaultMessage": "Lightning, on-chain Bitcoin, or card. Log in with your Nostr key. No KYC."
+    "defaultMessage": "يمكنك الدفع باستخدام شبكة لايتنينج، أو عملة البيتكوين مباشرةً على البلوك تشين، أو عن طريق البطاقة. سجّل الدخول باستخدام مفتاح نوستر الخاص بك. لا حاجة لتقديم معلومات تعريفية (KYC)."
   },
   "PlcGQq": {
     "defaultMessage": "Pay for this deployment before resizing it — an upgrade is charged pro-rata against the time left on the current period."
@@ -1281,7 +1281,7 @@
     "defaultMessage": "ماذا يحدث لفعالياتي إذا توقفت عن الدفع؟"
   },
   "U0GEAC": {
-    "defaultMessage": "Stop uploading your images and video to someone else's server. Route96 is a Blossom and NIP-96 media server, deployed on LNVPS in minutes, with storage and TLS included."
+    "defaultMessage": "توقف عن تحميل الصور ومقاطع الفيديو الخاصة بك على خوادم الآخرين. \"Route96\" هو خادم وسائط من نوع \"Blossom\" و\"NIP-96\"، ويمكن نشره على \"LNVPS\" في غضون دقائق، مع توفير مساحة تخزين وبروتوكول TLS."
   },
   "U7fZs8": {
     "defaultMessage": "كم يستغرق؟"
@@ -1290,7 +1290,7 @@
     "defaultMessage": "احتفظ بهذه البطاقة لاستخدامها في عمليات الدفع المستقبلية."
   },
   "UANa+W": {
-    "defaultMessage": "Route96 is a high-performance Blossom / NIP-96 server. It is <a>open source</a>, and it is ours — we wrote it and we run it. You are not trusting a black box; you can read every line, and you can leave with your data whenever you want."
+    "defaultMessage": "\"Route96\" هو خادم \"Blossom/NIP-96\" عالي الأداء. وهو برنامج <a>مفتوح المصدر</a>، وهو من تطويرنا — لقد قمنا ببرمجته ونحن ندير تشغيله. أنت لا تعتمد على نظام معقد وغير شفاف؛ يمكنك قراءة كل سطر من التعليمات البرمجية، ويمكنك الخروج ببياناتك متى شئت."
   },
   "UPP+wZ": {
     "defaultMessage": "يستخدم بواسطة {count,plural,one{الآلة الافتراضية.} other{الأجهزة الافتراضية}} {vms}"
@@ -1362,7 +1362,7 @@
     "defaultMessage": "{breakdown}، {storage} إجمالاً، هذا مناسب لخادم وسائط شخصي؛ وإذا كنت بحاجة إلى المزيد، يمكنك استخدام خادم افتراضي خاص (VPS) وتثبيت برنامج Route96 بنفسك لتوسيع نطاقه بشكل أكبر."
   },
   "W8nHSd": {
-    "defaultMessage": "FAQ"
+    "defaultMessage": "أسئلة متكررة."
   },
   "WEoZhh": {
     "defaultMessage": "تعذر العثور على اشتراك لتحصيل تكلفة هذه الترقية."
@@ -1497,7 +1497,7 @@
     "defaultMessage": "الحفظ يعيد تطبيق الإعدادات ويعيد تشغيل التطبيق."
   },
   "aLe15X": {
-    "defaultMessage": "Pay how you like"
+    "defaultMessage": "ادفع بالطريقة التي تفضلها."
   },
   "aPcXT9": {
     "defaultMessage": "يتم تجميع المدفوعات مع عمليات الإحالة الأخرى على الشبكة في معاملة واحدة، وذلك بعد تجاوز رصيدك الحد الأدنى المطلوب. ويتم خصم حصتك من رسوم الشبكة من رصيدك. هذا ينطبق فقط على عناوين الشبكة الرئيسية."
@@ -1830,7 +1830,7 @@
     "defaultMessage": "ملف SKILL.md"
   },
   "j52BNh": {
-    "defaultMessage": "Why self-host media"
+    "defaultMessage": "لماذا أقوم باستضافة ملفات الوسائط بنفسي؟"
   },
   "j7VE/p": {
     "defaultMessage": "معاملة BTC عادية — تُضاف بعد التأكيد"
@@ -1863,7 +1863,7 @@
     "defaultMessage": "وجّه سجل CNAME لهذا النطاق إلى اسم مضيف النشر بمجرد تعيينه. اتركه فارغًا للإزالة."
   },
   "jhyC12": {
-    "defaultMessage": "What is included"
+    "defaultMessage": "ما الذي يتضمنه؟"
   },
   "jmVweB": {
     "defaultMessage": "جارٍ تحميل مفاتيح SSH..."
@@ -1881,10 +1881,10 @@
     "defaultMessage": "IPv6"
   },
   "jzU8se": {
-    "defaultMessage": "Deploy Route96 — {price}/month"
+    "defaultMessage": "نشر تطبيق Route96 — {price}‏/شهر"
   },
   "k2S+Z0": {
-    "defaultMessage": "A protocol for storing and retrieving files addressed by their hash, designed to work with Nostr. NIP-96 is the older HTTP file-storage spec — Route96 speaks both."
+    "defaultMessage": "بروتوكول لتخزين واسترجاع الملفات باستخدام قيم التجزئة الخاصة بها، مصمم للعمل مع نظام \"نوستر\". يعتبر \"NIP-96\" المواصفة القديمة لتخزين الملفات عبر بروتوكول HTTP — بينما يدعم \"Route96\" كلا البروتوكولين."
   },
   "k9Pskm": {
     "defaultMessage": "تخزين SSD سريع"
@@ -1968,7 +1968,7 @@
     "defaultMessage": "التطبيقات المُدارة: قم بتشغيل البرنامج دون تشغيل الخادم."
   },
   "mDRXDi": {
-    "defaultMessage": "Nostr keeps your identity portable. Media has been the part that is not — your images live on someone else's host, under someone else's terms, and disappear when they do. A Blossom server puts that back under your key."
+    "defaultMessage": "تتيح لك منصة نوستر الاحتفاظ بهويتك وإمكانية نقلها. كانت الوسائط هي الجزء الذي لم يكن كذلك — صورك تُخزَّن على خادم شخص آخر، وتخضع لشروطه، وتختفي عندما يشاء. يسمح لك خادم \"Blossom\" باستعادة السيطرة عليها ووضعها تحت إشرافك."
   },
   "mHEBOr": {
     "defaultMessage": "هل يمكنك تثبيت برنامج \"بيتكوين كور\" على جهازي؟"
@@ -2121,7 +2121,7 @@
     "defaultMessage": "خدمات استضافة VPS في كيبيك، كندا، تبدأ من {price} باستثناء ضريبة القيمة المضافة. {minCpu}–{maxCpu} وحدة معالجة مركزية افتراضية، بحد أقصى {maxDisk} {diskType}ادفع بالبيتكوين عبر شبكة لايتنينغ أو مباشرةً على البلوك تشين."
   },
   "ps4K9r": {
-    "defaultMessage": "What is Blossom?"
+    "defaultMessage": "ما هو برنامج Blossom؟"
   },
   "pus6h6": {
     "defaultMessage": "يمكنك المغادرة في أي وقت. سيتوقف الكود عن توليد المزيد من الأرباح، ولن يمكن إعادة استخدامه."
@@ -2214,7 +2214,7 @@
     "defaultMessage": "تتوفر خدمة المراسلة المشفرة فقط لحسابات نوستر. لا يمتلك حسابك مفتاح نوستر لقراءة رسائل NIP-17 أو إرسالها. للحصول على المساعدة، يرجى استخدام علامة التبويب \"الدعم\"."
   },
   "sehISV": {
-    "defaultMessage": "Blossom Media Server Hosting from {price}/month"
+    "defaultMessage": "استضافة خادم الوسائط بلوسوم ابتداءً من {price} شهريًا."
   },
   "sn+Rj5": {
     "defaultMessage": "تسجيل الدخول بمفتاح مرور"
@@ -2388,7 +2388,7 @@
     "defaultMessage": "لا يمكن إجراء الترقية."
   },
   "xExBHw": {
-    "defaultMessage": "Your own hostname — <code>your-name.ie.apps.lnvps.cloud</code> — with automatic TLS"
+    "defaultMessage": "اسم المضيف الخاص بك — <code>your-name.ie.apps.lnvps.cloud</code> — مع تفعيل بروتوكول TLS تلقائيًا."
   },
   "xOnplm": {
     "defaultMessage": "جارٍ تحميل طرق الدفع…"

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -711,7 +711,7 @@
     "defaultMessage": "Verbindung unterbrochen."
   },
   "FZup6q": {
-    "defaultMessage": "Wo wird es gezeigt/ausgestrahlt?"
+    "defaultMessage": "Wo läuft er?"
   },
   "FazwRl": {
     "defaultMessage": "Versuchen Sie es noch einmal."

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -9,7 +9,7 @@
     "defaultMessage": "Abgehend/ausgehend"
   },
   "+Bj8tM": {
-    "defaultMessage": "Stopping retains your uploads; only deleting removes them"
+    "defaultMessage": "Wenn Sie das Anhalten auswählen, bleiben Ihre hochgeladenen Dateien erhalten; nur durch Löschen werden sie tatsächlich entfernt."
   },
   "+EHk4e": {
     "defaultMessage": "Ja. Das ist Ihr Gerät – installieren Sie, was immer Sie möchten."
@@ -171,7 +171,7 @@
     "defaultMessage": "Bestellung aufgeben"
   },
   "2lKQfH": {
-    "defaultMessage": "How much can I store?"
+    "defaultMessage": "Wie viel Speicherplatz steht mir zur Verfügung?"
   },
   "2mZOHz": {
     "defaultMessage": "Quote currency"
@@ -390,7 +390,7 @@
     "defaultMessage": "Jetzt bezahlen."
   },
   "7v5vj0": {
-    "defaultMessage": "Host your own media server — {price} a month"
+    "defaultMessage": "Betreiben Sie Ihren eigenen Medienserver – {price} pro Monat."
   },
   "7wbySo": {
     "defaultMessage": "Senden Sie uns eine direkte Nachricht, und unser Team wird sich bei Ihnen melden."
@@ -435,7 +435,7 @@
     "defaultMessage": "Zahlungsroute speichern"
   },
   "8dAKuZ": {
-    "defaultMessage": "Yes — CNAME, and the certificate is issued automatically once DNS resolves."
+    "defaultMessage": "Ja – CNAME, und das Zertifikat wird automatisch ausgestellt, sobald die DNS-Auflösung erfolgt ist."
   },
   "8ecw1u": {
     "defaultMessage": "Griffe"
@@ -711,7 +711,7 @@
     "defaultMessage": "Verbindung unterbrochen."
   },
   "FZup6q": {
-    "defaultMessage": "Where does it run?"
+    "defaultMessage": "Wo wird es gezeigt/ausgestrahlt?"
   },
   "FazwRl": {
     "defaultMessage": "Versuchen Sie es noch einmal."
@@ -837,7 +837,7 @@
     "defaultMessage": "Fertig."
   },
   "IbWc3k": {
-    "defaultMessage": "Dublin, Ireland."
+    "defaultMessage": "Dublin, Irland."
   },
   "Id24hd": {
     "defaultMessage": "Name *"
@@ -1071,7 +1071,7 @@
     "defaultMessage": "Keine Bestellung gefunden."
   },
   "Pk14hW": {
-    "defaultMessage": "Lightning, on-chain Bitcoin, or card. Log in with your Nostr key. No KYC."
+    "defaultMessage": "Zahlung per Lightning, On-Chain-Bitcoin oder Karte möglich. Melden Sie sich mit Ihrem Nostr-Schlüssel an. Keine Identitätsprüfung erforderlich."
   },
   "PlcGQq": {
     "defaultMessage": "Pay for this deployment before resizing it — an upgrade is charged pro-rata against the time left on the current period."
@@ -1281,7 +1281,7 @@
     "defaultMessage": "Was passiert mit meinen Veranstaltungen, wenn ich die Zahlungen einstelle?"
   },
   "U0GEAC": {
-    "defaultMessage": "Stop uploading your images and video to someone else's server. Route96 is a Blossom and NIP-96 media server, deployed on LNVPS in minutes, with storage and TLS included."
+    "defaultMessage": "Hören Sie auf, Ihre Bilder und Videos auf den Servern anderer hochzuladen. Route96 ist ein Blossom- und NIP-96-Medienserver, der innerhalb von Minuten auf LNVPS bereitgestellt wird und Speicherplatz sowie TLS umfasst."
   },
   "U7fZs8": {
     "defaultMessage": "Wie lange dauert es?"
@@ -1290,7 +1290,7 @@
     "defaultMessage": "Bewahren Sie diese Karte für zukünftige Zahlungen auf."
   },
   "UANa+W": {
-    "defaultMessage": "Route96 is a high-performance Blossom / NIP-96 server. It is <a>open source</a>, and it is ours — we wrote it and we run it. You are not trusting a black box; you can read every line, and you can leave with your data whenever you want."
+    "defaultMessage": "Route96 ist ein leistungsstarker Blossom-/NIP-96-Server. Er ist <a>Open Source</a>, und er gehört uns – wir haben ihn entwickelt und betreiben ihn. Sie müssen keinem Blackbox-System vertrauen; Sie können jede Zeile des Codes einsehen und Ihre Daten jederzeit abrufen."
   },
   "UPP+wZ": {
     "defaultMessage": "Wird verwendet von {count,plural,one{VM} other{Virtuelle Maschinen}}: {vms}"
@@ -1362,7 +1362,7 @@
     "defaultMessage": "{breakdown}. {storage} insgesamt. Für einen privaten Medienserver ist das ausreichend; wenn Sie mehr benötigen, können Sie durch die Installation von Route96 auf einem virtuellen Privaten Server (VPS) die Kapazität weiter ausbauen."
   },
   "W8nHSd": {
-    "defaultMessage": "FAQ"
+    "defaultMessage": "Häufig gestellte Fragen"
   },
   "WEoZhh": {
     "defaultMessage": "Für dieses Upgrade konnte kein Abonnement zur Abrechnung gefunden werden."
@@ -1497,7 +1497,7 @@
     "defaultMessage": "Beim Speichern wird die Konfiguration neu angewendet und die App neu gestartet."
   },
   "aLe15X": {
-    "defaultMessage": "Pay how you like"
+    "defaultMessage": "Bezahlen Sie so, wie es Ihnen am besten passt."
   },
   "aPcXT9": {
     "defaultMessage": "Auszahlungen werden zusammen mit anderen On-Chain-Referenzen zu einer einzigen Transaktion gebündelt, sobald Ihr Guthaben den Mindestbetrag erreicht. Ihr Anteil an der Netzwerkgebühr wird von Ihrem Guthaben abgezogen. Nur für Mainnet-Adressen."
@@ -1830,7 +1830,7 @@
     "defaultMessage": "SKILL.md"
   },
   "j52BNh": {
-    "defaultMessage": "Why self-host media"
+    "defaultMessage": "Warum sollte man Medieninhalte selbst hosten?"
   },
   "j7VE/p": {
     "defaultMessage": "Normale BTC-Transaktion — wird nach Bestätigung gutgeschrieben"
@@ -1863,7 +1863,7 @@
     "defaultMessage": "Richten Sie einen CNAME für diese Domain auf den Hostnamen der Bereitstellung, sobald dieser zugewiesen ist. Leer lassen zum Entfernen."
   },
   "jhyC12": {
-    "defaultMessage": "What is included"
+    "defaultMessage": "Was ist enthalten?"
   },
   "jmVweB": {
     "defaultMessage": "SSH-Schlüssel werden geladen ..."
@@ -1881,10 +1881,10 @@
     "defaultMessage": "IPv6"
   },
   "jzU8se": {
-    "defaultMessage": "Deploy Route96 — {price}/month"
+    "defaultMessage": "Route96 bereitstellen – {price} pro Monat"
   },
   "k2S+Z0": {
-    "defaultMessage": "A protocol for storing and retrieving files addressed by their hash, designed to work with Nostr. NIP-96 is the older HTTP file-storage spec — Route96 speaks both."
+    "defaultMessage": "Ein Protokoll zum Speichern und Abrufen von Dateien, das auf deren Hash-Wert basiert und für die Verwendung mit Nostr entwickelt wurde. NIP-96 ist die ältere HTTP-Spezifikation für die Dateispeicherung – Route96 unterstützt beide."
   },
   "k9Pskm": {
     "defaultMessage": "Schneller Solid-State-Speicher"
@@ -1968,7 +1968,7 @@
     "defaultMessage": "Verwaltete Apps: Führen Sie die Software aus, ohne den Server zu starten."
   },
   "mDRXDi": {
-    "defaultMessage": "Nostr keeps your identity portable. Media has been the part that is not — your images live on someone else's host, under someone else's terms, and disappear when they do. A Blossom server puts that back under your key."
+    "defaultMessage": "Nostr ermöglicht es Ihnen, Ihre Identität zu erhalten und sie einfach zu übertragen. Bisher waren Medieninhalte das Problem – Ihre Bilder wurden auf den Servern anderer gespeichert, unter deren Bedingungen und verschwanden irgendwann. Ein Blossom-Server stellt sicher, dass Sie die Kontrolle darüber behalten."
   },
   "mHEBOr": {
     "defaultMessage": "Installieren Sie Bitcoin Core für mich?"
@@ -2121,7 +2121,7 @@
     "defaultMessage": "VPS-Hosting in Québec, Kanada, ab {price} zzgl. Mehrwertsteuer. {minCpu}–{maxCpu} virtuelle CPU, bis zu {maxDisk} {diskType}Sie können mit Bitcoin über das Lightning-Netzwerk oder direkt (on-chain) bezahlen."
   },
   "ps4K9r": {
-    "defaultMessage": "What is Blossom?"
+    "defaultMessage": "Was ist Blossom?"
   },
   "pus6h6": {
     "defaultMessage": "Sie können dies jederzeit tun. Ihr Code generiert ab diesem Zeitpunkt keine weiteren Prämien und kann nicht mehr verwendet werden."
@@ -2214,7 +2214,7 @@
     "defaultMessage": "Verschlüsselte Nachrichten sind nur für Nostr-Konten verfügbar. Ihr Konto verfügt über keinen Nostr-Schlüssel, um NIP-17-Nachrichten zu lesen oder zu senden. Bei Fragen wenden Sie sich bitte an den Support."
   },
   "sehISV": {
-    "defaultMessage": "Blossom Media Server Hosting from {price}/month"
+    "defaultMessage": "Hosting für den Blossom Media Server ab {price} pro Monat."
   },
   "sn+Rj5": {
     "defaultMessage": "Mit Passkey anmelden"
@@ -2388,7 +2388,7 @@
     "defaultMessage": "Upgrade nicht verfügbar."
   },
   "xExBHw": {
-    "defaultMessage": "Your own hostname — <code>your-name.ie.apps.lnvps.cloud</code> — with automatic TLS"
+    "defaultMessage": "Ihr eigener Hostname – <code>your-name.ie.apps.lnvps.cloud</code> – mit automatischer TLS-Verschlüsselung."
   },
   "xOnplm": {
     "defaultMessage": "Zahlungsmethoden werden geladen …"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -9,7 +9,7 @@
     "defaultMessage": "Salida."
   },
   "+Bj8tM": {
-    "defaultMessage": "Stopping retains your uploads; only deleting removes them"
+    "defaultMessage": "Si detienes la operación, se conservarán tus archivos subidos; solo al eliminarlos, dejarán de estar disponibles."
   },
   "+EHk4e": {
     "defaultMessage": "Sí. Es tu computadora, así que instala lo que quieras."
@@ -171,7 +171,7 @@
     "defaultMessage": "Crear pedido"
   },
   "2lKQfH": {
-    "defaultMessage": "How much can I store?"
+    "defaultMessage": "¿Cuánto espacio de almacenamiento tengo disponible?"
   },
   "2mZOHz": {
     "defaultMessage": "Quote currency"
@@ -390,7 +390,7 @@
     "defaultMessage": "Pague ahora."
   },
   "7v5vj0": {
-    "defaultMessage": "Host your own media server — {price} a month"
+    "defaultMessage": "Aloja tu propio servidor multimedia: {price} al mes."
   },
   "7wbySo": {
     "defaultMessage": "Envíenos un mensaje directamente y el equipo se pondrá en contacto con usted."
@@ -435,7 +435,7 @@
     "defaultMessage": "Guardar la ruta de pago."
   },
   "8dAKuZ": {
-    "defaultMessage": "Yes — CNAME, and the certificate is issued automatically once DNS resolves."
+    "defaultMessage": "Sí, se utiliza un registro CNAME y el certificado se emite automáticamente una vez que se resuelve la consulta DNS."
   },
   "8ecw1u": {
     "defaultMessage": "Manijas"
@@ -711,7 +711,7 @@
     "defaultMessage": "Desconectado."
   },
   "FZup6q": {
-    "defaultMessage": "Where does it run?"
+    "defaultMessage": "¿Dónde se proyecta?"
   },
   "FazwRl": {
     "defaultMessage": "Inténtalo de nuevo."
@@ -837,7 +837,7 @@
     "defaultMessage": "Listo."
   },
   "IbWc3k": {
-    "defaultMessage": "Dublin, Ireland."
+    "defaultMessage": "Dublín, Irlanda."
   },
   "Id24hd": {
     "defaultMessage": "Nombre *"
@@ -1071,7 +1071,7 @@
     "defaultMessage": "No se encontró ninguna orden."
   },
   "Pk14hW": {
-    "defaultMessage": "Lightning, on-chain Bitcoin, or card. Log in with your Nostr key. No KYC."
+    "defaultMessage": "Puedes pagar con Lightning Network, con bitcoin directamente en la cadena de bloques o con tarjeta. Inicia sesión con tu clave Nostr. No se requiere verificación de identidad (KYC)."
   },
   "PlcGQq": {
     "defaultMessage": "Pay for this deployment before resizing it — an upgrade is charged pro-rata against the time left on the current period."
@@ -1281,7 +1281,7 @@
     "defaultMessage": "¿Qué ocurre con mis eventos si dejo de pagar?"
   },
   "U0GEAC": {
-    "defaultMessage": "Stop uploading your images and video to someone else's server. Route96 is a Blossom and NIP-96 media server, deployed on LNVPS in minutes, with storage and TLS included."
+    "defaultMessage": "Deje de subir sus imágenes y vídeos al servidor de otra persona. Route96 es un servidor multimedia Blossom y NIP-96, que se puede implementar en LNVPS en cuestión de minutos e incluye almacenamiento y TLS."
   },
   "U7fZs8": {
     "defaultMessage": "¿Cuánto tiempo tarda?"
@@ -1290,7 +1290,7 @@
     "defaultMessage": "Guarde esta tarjeta para futuros pagos."
   },
   "UANa+W": {
-    "defaultMessage": "Route96 is a high-performance Blossom / NIP-96 server. It is <a>open source</a>, and it is ours — we wrote it and we run it. You are not trusting a black box; you can read every line, and you can leave with your data whenever you want."
+    "defaultMessage": "Route96 es un servidor Blossom/NIP-96 de alto rendimiento. Es de <a>código abierto</a> y pertenece a nosotros: lo hemos creado y gestionamos. No estás confiando en una caja negra; puedes leer cada línea del código y, cuando quieras, puedes irte con tus datos."
   },
   "UPP+wZ": {
     "defaultMessage": "En uso por {count,plural,one{VM} other{Máquinas virtuales}}: {vms}"
@@ -1362,7 +1362,7 @@
     "defaultMessage": "{breakdown}. {storage} en total. Para un servidor multimedia de uso personal, esto es suficiente; si necesita más capacidad, puede instalar Route96 en un VPS y ampliarlo según sus necesidades."
   },
   "W8nHSd": {
-    "defaultMessage": "FAQ"
+    "defaultMessage": "Preguntas frecuentes"
   },
   "WEoZhh": {
     "defaultMessage": "No se encontró una suscripción a la que facturar esta mejora."
@@ -1497,7 +1497,7 @@
     "defaultMessage": "Al guardar se vuelve a aplicar la configuración y se reinicia la aplicación."
   },
   "aLe15X": {
-    "defaultMessage": "Pay how you like"
+    "defaultMessage": "Pague como prefiera."
   },
   "aPcXT9": {
     "defaultMessage": "Los pagos se agrupan con los de otros remitentes en la cadena de bloques y se realizan en una sola transacción una vez que su saldo supera el mínimo requerido. Su parte de la comisión de la red se deduce de su saldo. Solo se aceptan direcciones de la red principal."
@@ -1830,7 +1830,7 @@
     "defaultMessage": "SKILL.md"
   },
   "j52BNh": {
-    "defaultMessage": "Why self-host media"
+    "defaultMessage": "¿Por qué alojar contenido multimedia en un servidor propio?"
   },
   "j7VE/p": {
     "defaultMessage": "Transacción BTC estándar — se acredita tras la confirmación"
@@ -1863,7 +1863,7 @@
     "defaultMessage": "Apunte un CNAME de este dominio al nombre de host del despliegue cuando esté asignado. Déjelo vacío para eliminarlo."
   },
   "jhyC12": {
-    "defaultMessage": "What is included"
+    "defaultMessage": "¿Qué incluye?"
   },
   "jmVweB": {
     "defaultMessage": "Cargando las claves SSH..."
@@ -1881,10 +1881,10 @@
     "defaultMessage": "IPv6"
   },
   "jzU8se": {
-    "defaultMessage": "Deploy Route96 — {price}/month"
+    "defaultMessage": "Implementa Route96: {price} al mes."
   },
   "k2S+Z0": {
-    "defaultMessage": "A protocol for storing and retrieving files addressed by their hash, designed to work with Nostr. NIP-96 is the older HTTP file-storage spec — Route96 speaks both."
+    "defaultMessage": "Un protocolo para almacenar y recuperar archivos mediante su código hash, diseñado para funcionar con Nostr. NIP-96 es la especificación más antigua para el almacenamiento de archivos a través de HTTP; Route96 es compatible con ambas."
   },
   "k9Pskm": {
     "defaultMessage": "Almacenamiento SSD rápido"
@@ -1968,7 +1968,7 @@
     "defaultMessage": "Aplicaciones gestionadas: ejecute el software sin necesidad de ejecutar el servidor."
   },
   "mDRXDi": {
-    "defaultMessage": "Nostr keeps your identity portable. Media has been the part that is not — your images live on someone else's host, under someone else's terms, and disappear when they do. A Blossom server puts that back under your key."
+    "defaultMessage": "Nostr mantiene tu identidad accesible en cualquier lugar. Los archivos multimedia son la parte que no lo hace: tus imágenes se almacenan en el servidor de otra persona, bajo sus condiciones, y desaparecen cuando esa persona decide hacerlo. Un servidor Blossom permite que vuelvas a tener el control."
   },
   "mHEBOr": {
     "defaultMessage": "¿Me instalas Bitcoin Core?"
@@ -2121,7 +2121,7 @@
     "defaultMessage": "Alojamiento VPS en Quebec, Canadá, desde {price} sin IVA. {minCpu}–{maxCpu} vCPU, hasta {maxDisk} {diskType}Puede pagar con Bitcoin a través de Lightning o directamente en la cadena de bloques."
   },
   "ps4K9r": {
-    "defaultMessage": "What is Blossom?"
+    "defaultMessage": "¿Qué es Blossom?"
   },
   "pus6h6": {
     "defaultMessage": "Puede utilizar el código cuando quiera. Una vez utilizado, dejará de generar beneficios y no podrá volver a usarse."
@@ -2214,7 +2214,7 @@
     "defaultMessage": "El servicio de mensajería cifrada solo está disponible para las cuentas de Nostr. Su cuenta no tiene una clave de Nostr necesaria para leer o enviar mensajes NIP-17. Si necesita ayuda, utilice la pestaña de Soporte."
   },
   "sehISV": {
-    "defaultMessage": "Blossom Media Server Hosting from {price}/month"
+    "defaultMessage": "Alojamiento de Blossom Media Server desde {price} al mes."
   },
   "sn+Rj5": {
     "defaultMessage": "Iniciar sesión con clave de acceso"
@@ -2388,7 +2388,7 @@
     "defaultMessage": "No se puede realizar la actualización."
   },
   "xExBHw": {
-    "defaultMessage": "Your own hostname — <code>your-name.ie.apps.lnvps.cloud</code> — with automatic TLS"
+    "defaultMessage": "Su propio nombre de dominio — <code>su-nombre.ie.apps.lnvps.cloud</code> — con TLS habilitado automáticamente."
   },
   "xOnplm": {
     "defaultMessage": "Cargando los métodos de pago…"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -711,7 +711,7 @@
     "defaultMessage": "Desconectado."
   },
   "FZup6q": {
-    "defaultMessage": "¿Dónde se proyecta?"
+    "defaultMessage": "¿Dónde se ejecuta?"
   },
   "FazwRl": {
     "defaultMessage": "Inténtalo de nuevo."

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -9,7 +9,7 @@
     "defaultMessage": "Sortant(e) / En direction de la destination"
   },
   "+Bj8tM": {
-    "defaultMessage": "Stopping retains your uploads; only deleting removes them"
+    "defaultMessage": "L’arrêt du processus conserve vos fichiers téléchargés ; seule la suppression les efface."
   },
   "+EHk4e": {
     "defaultMessage": "Oui. C’est votre ordinateur, installez ce que vous voulez."
@@ -171,7 +171,7 @@
     "defaultMessage": "Créer une commande"
   },
   "2lKQfH": {
-    "defaultMessage": "How much can I store?"
+    "defaultMessage": "Quelle quantité de données puis-je stocker ?"
   },
   "2mZOHz": {
     "defaultMessage": "Quote currency"
@@ -390,7 +390,7 @@
     "defaultMessage": "Payer maintenant."
   },
   "7v5vj0": {
-    "defaultMessage": "Host your own media server — {price} a month"
+    "defaultMessage": "Hébergez votre propre serveur multimédia – {price} par mois."
   },
   "7wbySo": {
     "defaultMessage": "Envoyez-nous un message directement et notre équipe vous répondra dans les plus brefs délais."
@@ -435,7 +435,7 @@
     "defaultMessage": "Enregistrer la méthode de paiement."
   },
   "8dAKuZ": {
-    "defaultMessage": "Yes — CNAME, and the certificate is issued automatically once DNS resolves."
+    "defaultMessage": "Oui, utilisez un enregistrement CNAME, et le certificat sera émis automatiquement une fois que la résolution DNS aura eu lieu."
   },
   "8ecw1u": {
     "defaultMessage": "Poignées"
@@ -711,7 +711,7 @@
     "defaultMessage": "Déconnecté"
   },
   "FZup6q": {
-    "defaultMessage": "Where does it run?"
+    "defaultMessage": "Où est-ce que ça se déroule ?"
   },
   "FazwRl": {
     "defaultMessage": "Réessayez."
@@ -837,7 +837,7 @@
     "defaultMessage": "Prêt(e)"
   },
   "IbWc3k": {
-    "defaultMessage": "Dublin, Ireland."
+    "defaultMessage": "Dublin, Irlande."
   },
   "Id24hd": {
     "defaultMessage": "Nom *"
@@ -1071,7 +1071,7 @@
     "defaultMessage": "Aucune commande n’a été trouvée."
   },
   "Pk14hW": {
-    "defaultMessage": "Lightning, on-chain Bitcoin, or card. Log in with your Nostr key. No KYC."
+    "defaultMessage": "Paiement par Lightning Network, directement sur la blockchain Bitcoin, ou par carte. Connectez-vous avec votre clé Nostr. Pas de vérification d’identité."
   },
   "PlcGQq": {
     "defaultMessage": "Pay for this deployment before resizing it — an upgrade is charged pro-rata against the time left on the current period."
@@ -1281,7 +1281,7 @@
     "defaultMessage": "Que se passe-t-il avec mes événements si j’arrête de payer ?"
   },
   "U0GEAC": {
-    "defaultMessage": "Stop uploading your images and video to someone else's server. Route96 is a Blossom and NIP-96 media server, deployed on LNVPS in minutes, with storage and TLS included."
+    "defaultMessage": "Arrêtez de téléverser vos images et vidéos sur le serveur d’une autre personne. Route96 est un serveur multimédia Blossom et NIP-96, déployé sur LNVPS en quelques minutes, avec espace de stockage et TLS inclus."
   },
   "U7fZs8": {
     "defaultMessage": "Combien de temps cela prend-il ?"
@@ -1290,7 +1290,7 @@
     "defaultMessage": "Conservez cette carte pour les prochains paiements."
   },
   "UANa+W": {
-    "defaultMessage": "Route96 is a high-performance Blossom / NIP-96 server. It is <a>open source</a>, and it is ours — we wrote it and we run it. You are not trusting a black box; you can read every line, and you can leave with your data whenever you want."
+    "defaultMessage": "Route96 est un serveur Blossom/NIP-96 performant. Il est en <a>source ouverte</a>, et il nous appartient : c’est nous qui l’avons créé et qui le gérons. Vous n’avez pas à faire confiance à une boîte noire ; vous pouvez lire chaque ligne de code, et vous pouvez repartir avec vos données quand vous le souhaitez."
   },
   "UPP+wZ": {
     "defaultMessage": "En utilisation par : {count,plural,one{VM} other{Machines virtuelles}}: {vms}"
@@ -1362,7 +1362,7 @@
     "defaultMessage": "{breakdown}. {storage} au total. Pour un serveur multimédia personnel, c’est suffisant ; si vous avez besoin de plus de ressources, vous pouvez installer Route96 sur un serveur virtuel privé (VPS) et ainsi augmenter sa capacité."
   },
   "W8nHSd": {
-    "defaultMessage": "FAQ"
+    "defaultMessage": "Foire aux questions"
   },
   "WEoZhh": {
     "defaultMessage": "Impossible de trouver un abonnement sur lequel facturer cette mise à niveau."
@@ -1497,7 +1497,7 @@
     "defaultMessage": "L'enregistrement réapplique la configuration et redémarre l'application."
   },
   "aLe15X": {
-    "defaultMessage": "Pay how you like"
+    "defaultMessage": "Payez comme vous le souhaitez."
   },
   "aPcXT9": {
     "defaultMessage": "Les paiements sont regroupés avec les autres références sur la chaîne dans une seule transaction une fois que votre solde atteint le minimum requis. Votre part des frais du réseau est déduite de votre solde. Uniquement pour les adresses du réseau principal."
@@ -1830,7 +1830,7 @@
     "defaultMessage": "SKILL.md"
   },
   "j52BNh": {
-    "defaultMessage": "Why self-host media"
+    "defaultMessage": "Pourquoi héberger soi-même ses contenus multimédias ?"
   },
   "j7VE/p": {
     "defaultMessage": "Transaction BTC standard — créditée après confirmation"
@@ -1863,7 +1863,7 @@
     "defaultMessage": "Faites pointer un CNAME de ce domaine vers le nom d'hôte du déploiement une fois celui-ci attribué. Laissez vide pour supprimer."
   },
   "jhyC12": {
-    "defaultMessage": "What is included"
+    "defaultMessage": "Qu’est-ce qui est inclus ?"
   },
   "jmVweB": {
     "defaultMessage": "Chargement des clés SSH…"
@@ -1881,10 +1881,10 @@
     "defaultMessage": "IPv6"
   },
   "jzU8se": {
-    "defaultMessage": "Deploy Route96 — {price}/month"
+    "defaultMessage": "Déployez Route96 – {price} par mois."
   },
   "k2S+Z0": {
-    "defaultMessage": "A protocol for storing and retrieving files addressed by their hash, designed to work with Nostr. NIP-96 is the older HTTP file-storage spec — Route96 speaks both."
+    "defaultMessage": "Il s’agit d’un protocole permettant de stocker et de récupérer des fichiers en utilisant leur hachage, conçu pour fonctionner avec Nostr. La norme NIP-96 est la spécification plus ancienne pour le stockage de fichiers via HTTP ; Route96 prend en charge les deux normes."
   },
   "k9Pskm": {
     "defaultMessage": "Stockage SSD rapide"
@@ -1968,7 +1968,7 @@
     "defaultMessage": "Applications gérées : exécutez le logiciel sans démarrer le serveur."
   },
   "mDRXDi": {
-    "defaultMessage": "Nostr keeps your identity portable. Media has been the part that is not — your images live on someone else's host, under someone else's terms, and disappear when they do. A Blossom server puts that back under your key."
+    "defaultMessage": "Nostr permet de conserver le contrôle sur votre identité numérique. Les médias sont l’élément qui pose problème : vos images sont hébergées sur les serveurs d’un tiers, soumises aux conditions d’utilisation de ce tiers, et disparaissent lorsque ce dernier décide de le faire. Un serveur Blossom rétablit ce contrôle en vous permettant de gérer ces éléments."
   },
   "mHEBOr": {
     "defaultMessage": "Pouvez-vous installer Bitcoin Core pour moi ?"
@@ -2121,7 +2121,7 @@
     "defaultMessage": "Hébergement VPS au Québec, Canada, à partir de {price} hors TVA. {minCpu}–{maxCpu} vCPU, jusqu’à {maxDisk} {diskType}Vous pouvez payer en Bitcoin, soit via le réseau Lightning, soit directement sur la chaîne de blocs."
   },
   "ps4K9r": {
-    "defaultMessage": "What is Blossom?"
+    "defaultMessage": "Qu'est-ce que Blossom ?"
   },
   "pus6h6": {
     "defaultMessage": "Vous pouvez quitter le jeu à tout moment. Votre code cessera de générer des récompenses et ne pourra plus être utilisé."
@@ -2214,7 +2214,7 @@
     "defaultMessage": "Le chiffrement des messages n’est disponible que pour les comptes Nostr. Votre compte ne dispose pas de clé Nostr permettant de lire ou d’envoyer des messages NIP-17. Pour obtenir de l’aide, veuillez utiliser l’onglet Assistance."
   },
   "sehISV": {
-    "defaultMessage": "Blossom Media Server Hosting from {price}/month"
+    "defaultMessage": "Hébergement du serveur multimédia Blossom à partir de {price} par mois."
   },
   "sn+Rj5": {
     "defaultMessage": "Se connecter avec une clé d'accès"
@@ -2388,7 +2388,7 @@
     "defaultMessage": "Mise à niveau non disponible."
   },
   "xExBHw": {
-    "defaultMessage": "Your own hostname — <code>your-name.ie.apps.lnvps.cloud</code> — with automatic TLS"
+    "defaultMessage": "Votre propre nom d’hôte, soit <code>your-name.ie.apps.lnvps.cloud</code>, avec activation automatique du protocole TLS."
   },
   "xOnplm": {
     "defaultMessage": "Chargement des méthodes de paiement…"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -711,7 +711,7 @@
     "defaultMessage": "Déconnecté"
   },
   "FZup6q": {
-    "defaultMessage": "Où est-ce que ça se déroule ?"
+    "defaultMessage": "Où fonctionne-t-il ?"
   },
   "FazwRl": {
     "defaultMessage": "Réessayez."

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -9,7 +9,7 @@
     "defaultMessage": "発信。"
   },
   "+Bj8tM": {
-    "defaultMessage": "Stopping retains your uploads; only deleting removes them"
+    "defaultMessage": "停止してもアップロードしたデータは保持されます。削除した場合のみ、データが完全に消去されます。"
   },
   "+EHk4e": {
     "defaultMessage": "はい。これはあなたのコンピューターです。好きなものをインストールしてください。"
@@ -171,7 +171,7 @@
     "defaultMessage": "注文を作成する"
   },
   "2lKQfH": {
-    "defaultMessage": "How much can I store?"
+    "defaultMessage": "どれくらいのデータを保存できますか？"
   },
   "2mZOHz": {
     "defaultMessage": "Quote currency"
@@ -390,7 +390,7 @@
     "defaultMessage": "今すぐお支払いください。"
   },
   "7v5vj0": {
-    "defaultMessage": "Host your own media server — {price} a month"
+    "defaultMessage": "独自のメディアサーバーを構築して運用しましょう。月額{price}です。"
   },
   "7wbySo": {
     "defaultMessage": "直接メッセージをお送りいただければ、担当者が後ほどご連絡いたします。"
@@ -435,7 +435,7 @@
     "defaultMessage": "支払い方法を保存する"
   },
   "8dAKuZ": {
-    "defaultMessage": "Yes — CNAME, and the certificate is issued automatically once DNS resolves."
+    "defaultMessage": "はい、CNAMEレコードを設定し、DNSが解決されると証明書は自動的に発行されます。"
   },
   "8ecw1u": {
     "defaultMessage": "ハンドル"
@@ -711,7 +711,7 @@
     "defaultMessage": "接続が切断されました。"
   },
   "FZup6q": {
-    "defaultMessage": "Where does it run?"
+    "defaultMessage": "どこで（プログラムなどが）実行されますか？"
   },
   "FazwRl": {
     "defaultMessage": "もう一度試してください。"
@@ -837,7 +837,7 @@
     "defaultMessage": "準備完了。"
   },
   "IbWc3k": {
-    "defaultMessage": "Dublin, Ireland."
+    "defaultMessage": "アイルランドのダブリン。"
   },
   "Id24hd": {
     "defaultMessage": "名前 *"
@@ -1071,7 +1071,7 @@
     "defaultMessage": "該当する注文は見つかりませんでした。"
   },
   "Pk14hW": {
-    "defaultMessage": "Lightning, on-chain Bitcoin, or card. Log in with your Nostr key. No KYC."
+    "defaultMessage": "ライトニングネットワーク、オンチェーンのビットコイン、またはカードで支払い。Nostrキーを使ってログインしてください。本人確認は不要です。"
   },
   "PlcGQq": {
     "defaultMessage": "Pay for this deployment before resizing it — an upgrade is charged pro-rata against the time left on the current period."
@@ -1281,7 +1281,7 @@
     "defaultMessage": "支払いを停止した場合、登録したイベントはどうなりますか？"
   },
   "U0GEAC": {
-    "defaultMessage": "Stop uploading your images and video to someone else's server. Route96 is a Blossom and NIP-96 media server, deployed on LNVPS in minutes, with storage and TLS included."
+    "defaultMessage": "他人のサーバーに画像や動画をアップロードするのをやめましょう。Route96は、BlossomとNIP-96メディアサーバーであり、LNVPS上に数分で展開でき、ストレージとTLSが含まれています。"
   },
   "U7fZs8": {
     "defaultMessage": "どれくらいの時間がかかりますか？"
@@ -1290,7 +1290,7 @@
     "defaultMessage": "このカードを保存して、今後の支払いにご利用ください。"
   },
   "UANa+W": {
-    "defaultMessage": "Route96 is a high-performance Blossom / NIP-96 server. It is <a>open source</a>, and it is ours — we wrote it and we run it. You are not trusting a black box; you can read every line, and you can leave with your data whenever you want."
+    "defaultMessage": "Route96は、高性能なBlossom/NIP-96サーバーです。これは<a>オープンソース</a>であり、私たち自身で開発し、運用しています。つまり、ブラックボックスに頼る必要はありません。すべてのコードを閲覧でき、いつでも好きなときにデータを持ち出すことができます。"
   },
   "UPP+wZ": {
     "defaultMessage": "使用状況： {count,plural,one{仮想マシン} other{仮想マシン}}： {vms}"
@@ -1362,7 +1362,7 @@
     "defaultMessage": "{breakdown}、 {storage} 合計で。快適な個人用メディアサーバーを構築するには、必要に応じてRoute96をインストールしたVPSを利用することで、さらに拡張できます。"
   },
   "W8nHSd": {
-    "defaultMessage": "FAQ"
+    "defaultMessage": "よくある質問"
   },
   "WEoZhh": {
     "defaultMessage": "このアップグレードを請求するサブスクリプションが見つかりませんでした。"
@@ -1497,7 +1497,7 @@
     "defaultMessage": "保存すると設定が再適用され、アプリが再起動します。"
   },
   "aLe15X": {
-    "defaultMessage": "Pay how you like"
+    "defaultMessage": "好きな支払い方法でどうぞ。"
   },
   "aPcXT9": {
     "defaultMessage": "お支払いについては、残高が最低額を超えた時点で、他のオンチェーン・リファラーからの支払いとまとめて1つのトランザクションとして処理されます。ネットワーク手数料の一部がお客様の残高から差し引かれます。対象はメインネットのアドレスのみです。"
@@ -1830,7 +1830,7 @@
     "defaultMessage": "SKILL.md"
   },
   "j52BNh": {
-    "defaultMessage": "Why self-host media"
+    "defaultMessage": "なぜ自分でメディアをホストするのか。"
   },
   "j7VE/p": {
     "defaultMessage": "通常のBTCトランザクション — 承認後に反映されます"
@@ -1863,7 +1863,7 @@
     "defaultMessage": "ホスト名が割り当てられたら、このドメインの CNAME をデプロイのホスト名に向けてください。削除するには空にしてください。"
   },
   "jhyC12": {
-    "defaultMessage": "What is included"
+    "defaultMessage": "何が含まれていますか？"
   },
   "jmVweB": {
     "defaultMessage": "SSHキーを読み込んでいます。"
@@ -1881,10 +1881,10 @@
     "defaultMessage": "IPv6"
   },
   "jzU8se": {
-    "defaultMessage": "Deploy Route96 — {price}/month"
+    "defaultMessage": "Route96をデプロイ — 月額{price}"
   },
   "k2S+Z0": {
-    "defaultMessage": "A protocol for storing and retrieving files addressed by their hash, designed to work with Nostr. NIP-96 is the older HTTP file-storage spec — Route96 speaks both."
+    "defaultMessage": "ハッシュ値に基づいてファイルを保存および検索するためのプロトコルで、Nostrと連携するように設計されています。NIP-96は、より古いHTTPファイルストレージ仕様です。Route96は両方の仕様に対応しています。"
   },
   "k9Pskm": {
     "defaultMessage": "高速なソリッドステートストレージ"
@@ -1968,7 +1968,7 @@
     "defaultMessage": "管理対象アプリ：サーバーを起動せずにソフトウェアを実行します。"
   },
   "mDRXDi": {
-    "defaultMessage": "Nostr keeps your identity portable. Media has been the part that is not — your images live on someone else's host, under someone else's terms, and disappear when they do. A Blossom server puts that back under your key."
+    "defaultMessage": "Nostrは、あなたのアイデンティティをどこでも利用できるようにします。従来のメディアでは、画像が他のサーバーに保存され、そのサーバーのルールに従い、必要に応じて削除されるため、自分の管理下にはありませんでした。Blossomサーバーを使用すれば、画像を再び自分の管理下に置くことができます。"
   },
   "mHEBOr": {
     "defaultMessage": "私にBitcoin Coreをインストールしてもらえますか？"
@@ -2121,7 +2121,7 @@
     "defaultMessage": "カナダのケベック州におけるVPSホスティングサービス {price} 付加価値税抜き。 {minCpu}－{maxCpu} vCPU、最大 {maxDisk} {diskType}ビットコインで、ライトニングネットワークまたはオンチェーンでの支払いが可能です。"
   },
   "ps4K9r": {
-    "defaultMessage": "What is Blossom?"
+    "defaultMessage": "Blossomとは何ですか？"
   },
   "pus6h6": {
     "defaultMessage": "いつでも解約できます。解約すると、コードの利用は停止され、再利用もできなくなります。"
@@ -2214,7 +2214,7 @@
     "defaultMessage": "暗号化されたメッセージ機能は、Nostrアカウントでのみ利用可能です。お客様のアカウントには、NIP-17形式のメッセージを読み書きするためのNostrキーが設定されていません。サポートが必要な場合は、サポートタブをご利用ください。"
   },
   "sehISV": {
-    "defaultMessage": "Blossom Media Server Hosting from {price}/month"
+    "defaultMessage": "Blossomメディアサーバーのホスティングサービスを月額{price}から。"
   },
   "sn+Rj5": {
     "defaultMessage": "パスキーでサインイン"
@@ -2388,7 +2388,7 @@
     "defaultMessage": "アップグレードは利用できません。"
   },
   "xExBHw": {
-    "defaultMessage": "Your own hostname — <code>your-name.ie.apps.lnvps.cloud</code> — with automatic TLS"
+    "defaultMessage": "お客様ご自身のホスト名（<code>your-name.ie.apps.lnvps.cloud</code>）に、TLSが自動的に適用されます。"
   },
   "xOnplm": {
     "defaultMessage": "支払い方法を読み込んでいます…。"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -711,7 +711,7 @@
     "defaultMessage": "接続が切断されました。"
   },
   "FZup6q": {
-    "defaultMessage": "どこで（プログラムなどが）実行されますか？"
+    "defaultMessage": "どこで実行されますか？"
   },
   "FazwRl": {
     "defaultMessage": "もう一度試してください。"

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -9,7 +9,7 @@
     "defaultMessage": "발신"
   },
   "+Bj8tM": {
-    "defaultMessage": "Stopping retains your uploads; only deleting removes them"
+    "defaultMessage": "중단하면 업로드한 내용이 그대로 유지됩니다. 완전히 삭제해야만 내용이 제거됩니다."
   },
   "+EHk4e": {
     "defaultMessage": "네, 맞습니다. 사용하시는 컴퓨터이므로 원하는 대로 설치하세요."
@@ -171,7 +171,7 @@
     "defaultMessage": "주문 생성"
   },
   "2lKQfH": {
-    "defaultMessage": "How much can I store?"
+    "defaultMessage": "얼마나 많은 데이터를 저장할 수 있나요?"
   },
   "2mZOHz": {
     "defaultMessage": "Quote currency"
@@ -390,7 +390,7 @@
     "defaultMessage": "지금 결제하세요."
   },
   "7v5vj0": {
-    "defaultMessage": "Host your own media server — {price} a month"
+    "defaultMessage": "자체 미디어 서버를 구축하여 운영하세요 — 월 {price}"
   },
   "7wbySo": {
     "defaultMessage": "메시지를 보내주시면 담당 팀에서 연락을 드릴 것입니다."
@@ -435,7 +435,7 @@
     "defaultMessage": "지급 경로 저장"
   },
   "8dAKuZ": {
-    "defaultMessage": "Yes — CNAME, and the certificate is issued automatically once DNS resolves."
+    "defaultMessage": "네, 맞습니다. CNAME 레코드를 설정하면 인증서가 자동으로 발급됩니다(DNS 확인 후)."
   },
   "8ecw1u": {
     "defaultMessage": "손잡이"
@@ -711,7 +711,7 @@
     "defaultMessage": "연결이 끊어졌습니다."
   },
   "FZup6q": {
-    "defaultMessage": "Where does it run?"
+    "defaultMessage": "어디에서 실행되나요?"
   },
   "FazwRl": {
     "defaultMessage": "다시 시도해 보세요."
@@ -837,7 +837,7 @@
     "defaultMessage": "준비 완료."
   },
   "IbWc3k": {
-    "defaultMessage": "Dublin, Ireland."
+    "defaultMessage": "아일랜드의 더블린."
   },
   "Id24hd": {
     "defaultMessage": "이름 *"
@@ -1071,7 +1071,7 @@
     "defaultMessage": "해당 주문을 찾을 수 없습니다."
   },
   "Pk14hW": {
-    "defaultMessage": "Lightning, on-chain Bitcoin, or card. Log in with your Nostr key. No KYC."
+    "defaultMessage": "라이트닝 네트워크, 온체인 비트코인 또는 카드 결제 방식 중 선택하세요. 노스트르 키를 사용하여 로그인합니다. 개인 정보 확인 절차는 없습니다."
   },
   "PlcGQq": {
     "defaultMessage": "Pay for this deployment before resizing it — an upgrade is charged pro-rata against the time left on the current period."
@@ -1281,7 +1281,7 @@
     "defaultMessage": "결제를 중단하면 내 이벤트는 어떻게 되나요?"
   },
   "U0GEAC": {
-    "defaultMessage": "Stop uploading your images and video to someone else's server. Route96 is a Blossom and NIP-96 media server, deployed on LNVPS in minutes, with storage and TLS included."
+    "defaultMessage": "다른 사람의 서버에 이미지와 동영상을 업로드하는 것을 중단하세요. Route96은 LNVPS에 몇 분 안에 배포할 수 있는 Blossom 및 NIP-96 미디어 서버이며, 저장 공간과 TLS가 함께 제공됩니다."
   },
   "U7fZs8": {
     "defaultMessage": "얼마나 걸립니까?"
@@ -1290,7 +1290,7 @@
     "defaultMessage": "이 카드를 저장하여 다음에 사용할 때 결제에 이용하세요."
   },
   "UANa+W": {
-    "defaultMessage": "Route96 is a high-performance Blossom / NIP-96 server. It is <a>open source</a>, and it is ours — we wrote it and we run it. You are not trusting a black box; you can read every line, and you can leave with your data whenever you want."
+    "defaultMessage": "Route96은 고성능 Blossom/NIP-96 서버입니다. 이 소프트웨어는 <a>오픈 소스</a>이며, 저희가 직접 개발하고 운영합니다. 따라서 사용자는 알 수 없는 블랙박스를 사용하는 것이 아니라 모든 코드를 확인하고 필요할 때 언제든지 데이터를 가져갈 수 있습니다."
   },
   "UPP+wZ": {
     "defaultMessage": "사용 중인 항목은 다음과 같습니다. {count,plural,one{가상 머신} other{가상 머신}}: {vms}"
@@ -1362,7 +1362,7 @@
     "defaultMessage": "{breakdown}. {storage} 전체적으로 보면 그렇습니다. 편리한 개인 미디어 서버를 원하신다면, 필요에 따라 직접 Route96을 설치한 VPS를 사용하여 확장할 수 있습니다."
   },
   "W8nHSd": {
-    "defaultMessage": "FAQ"
+    "defaultMessage": "자주 묻는 질문"
   },
   "WEoZhh": {
     "defaultMessage": "이 업그레이드를 청구할 구독을 찾을 수 없습니다."
@@ -1497,7 +1497,7 @@
     "defaultMessage": "저장하면 구성이 다시 적용되고 앱이 재시작됩니다."
   },
   "aLe15X": {
-    "defaultMessage": "Pay how you like"
+    "defaultMessage": "원하는 방식으로 결제하세요."
   },
   "aPcXT9": {
     "defaultMessage": "지급은 다른 온체인 추천인들과 함께 묶여 하나의 거래로 처리되며, 귀하의 잔액이 최소 금액을 초과하면 지급이 이루어집니다. 네트워크 수수료 중 귀하의 몫은 귀하의 잔액에서 차감됩니다. 메인넷 주소만 해당됩니다."
@@ -1830,7 +1830,7 @@
     "defaultMessage": "기술.md"
   },
   "j52BNh": {
-    "defaultMessage": "Why self-host media"
+    "defaultMessage": "미디어를 직접 호스팅해야 하는 이유는 무엇인가요?"
   },
   "j7VE/p": {
     "defaultMessage": "표준 BTC 트랜잭션 — 확인 후 반영됩니다"
@@ -1863,7 +1863,7 @@
     "defaultMessage": "배포 호스트 이름이 할당되면 이 도메인의 CNAME을 해당 호스트 이름으로 지정하세요. 제거하려면 비워 두세요."
   },
   "jhyC12": {
-    "defaultMessage": "What is included"
+    "defaultMessage": "무엇이 포함됩니까?"
   },
   "jmVweB": {
     "defaultMessage": "SSH 키를 불러오는 중..."
@@ -1881,10 +1881,10 @@
     "defaultMessage": "IPv6"
   },
   "jzU8se": {
-    "defaultMessage": "Deploy Route96 — {price}/month"
+    "defaultMessage": "Route96 배포 — 월 {price}"
   },
   "k2S+Z0": {
-    "defaultMessage": "A protocol for storing and retrieving files addressed by their hash, designed to work with Nostr. NIP-96 is the older HTTP file-storage spec — Route96 speaks both."
+    "defaultMessage": "해시값을 기준으로 파일을 저장하고 검색하는 프로토콜로, 노스트르(Nostr)와 함께 작동하도록 설계되었습니다. NIP-96은 이전 버전의 HTTP 파일 저장 방식이며, Route96은 두 가지 방식을 모두 지원합니다."
   },
   "k9Pskm": {
     "defaultMessage": "빠른 솔리드 스테이트 스토리지"
@@ -1968,7 +1968,7 @@
     "defaultMessage": "관리형 앱: 서버를 실행하지 않고 소프트웨어를 실행합니다."
   },
   "mDRXDi": {
-    "defaultMessage": "Nostr keeps your identity portable. Media has been the part that is not — your images live on someone else's host, under someone else's terms, and disappear when they do. A Blossom server puts that back under your key."
+    "defaultMessage": "Nostr은 사용자의 신원을 보관하고 이동성을 유지할 수 있도록 합니다. 기존에는 미디어가 그렇지 않았습니다. 즉, 사용자의 이미지는 다른 사람의 서버에 저장되고, 해당 서버 운영자의 정책에 따라 관리되며, 서버가 사라지면 이미지도 함께 사라집니다. Blossom 서버는 이러한 상황을 개선하여 사용자가 직접 제어할 수 있도록 합니다."
   },
   "mHEBOr": {
     "defaultMessage": "제가 비트코인 코어를 설치해 드릴까요?"
@@ -2121,7 +2121,7 @@
     "defaultMessage": "캐나다 퀘벡에서 제공하는 VPS 호스팅 서비스 {price} 부가가치세 제외. {minCpu}–{maxCpu} 가상 CPU, 최대 {maxDisk} {diskType}비트코인을 라이트닝 네트워크 또는 온체인 방식으로 결제하세요."
   },
   "ps4K9r": {
-    "defaultMessage": "What is Blossom?"
+    "defaultMessage": "Blossom이란 무엇인가요?"
   },
   "pus6h6": {
     "defaultMessage": "원하는 시간에 종료하세요. 코드는 더 이상 적립금을 제공하지 않으며 재사용할 수 없습니다."
@@ -2214,7 +2214,7 @@
     "defaultMessage": "암호화된 메시지 기능은 노스트르 계정에만 제공됩니다. 귀하의 계정에는 NIP-17 메시지를 읽거나 보내는 데 필요한 노스트르 키가 없습니다. 도움이 필요하시면 지원 섹션을 이용해 주시기 바랍니다."
   },
   "sehISV": {
-    "defaultMessage": "Blossom Media Server Hosting from {price}/month"
+    "defaultMessage": "블로섬 미디어 서버 호스팅, 월 {price}부터"
   },
   "sn+Rj5": {
     "defaultMessage": "패스키로 로그인"
@@ -2388,7 +2388,7 @@
     "defaultMessage": "업그레이드 불가"
   },
   "xExBHw": {
-    "defaultMessage": "Your own hostname — <code>your-name.ie.apps.lnvps.cloud</code> — with automatic TLS"
+    "defaultMessage": "사용자님의 호스트 이름은 다음과 같습니다. <code>your-name.ie.apps.lnvps.cloud</code>, 자동으로 TLS가 적용됩니다."
   },
   "xOnplm": {
     "defaultMessage": "결제 수단을 불러오는 중입니다…"

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -9,7 +9,7 @@
     "defaultMessage": "De saída / Em direção ao destino."
   },
   "+Bj8tM": {
-    "defaultMessage": "Stopping retains your uploads; only deleting removes them"
+    "defaultMessage": "Interromper mantém os seus ficheiros carregados; apenas apagá-los remove-os."
   },
   "+EHk4e": {
     "defaultMessage": "Sim. É o seu computador, instale o que quiser."
@@ -171,7 +171,7 @@
     "defaultMessage": "Criar Pedido"
   },
   "2lKQfH": {
-    "defaultMessage": "How much can I store?"
+    "defaultMessage": "Qual é a capacidade de armazenamento disponível?"
   },
   "2mZOHz": {
     "defaultMessage": "Quote currency"
@@ -390,7 +390,7 @@
     "defaultMessage": "Pague agora."
   },
   "7v5vj0": {
-    "defaultMessage": "Host your own media server — {price} a month"
+    "defaultMessage": "Crie o seu próprio servidor de mídia — {price} por mês."
   },
   "7wbySo": {
     "defaultMessage": "Envie-nos uma mensagem diretamente e a nossa equipa entrará em contacto consigo."
@@ -435,7 +435,7 @@
     "defaultMessage": "Guardar rota de pagamento"
   },
   "8dAKuZ": {
-    "defaultMessage": "Yes — CNAME, and the certificate is issued automatically once DNS resolves."
+    "defaultMessage": "Sim — CNAME e o certificado é emitido automaticamente assim que o DNS for resolvido."
   },
   "8ecw1u": {
     "defaultMessage": "Maçanetas/Puxadores"
@@ -711,7 +711,7 @@
     "defaultMessage": "Desligado/a"
   },
   "FZup6q": {
-    "defaultMessage": "Where does it run?"
+    "defaultMessage": "Onde é que ele funciona/é exibido?"
   },
   "FazwRl": {
     "defaultMessage": "Tente novamente."
@@ -837,7 +837,7 @@
     "defaultMessage": "Pronto."
   },
   "IbWc3k": {
-    "defaultMessage": "Dublin, Ireland."
+    "defaultMessage": "Dublim, Irlanda."
   },
   "Id24hd": {
     "defaultMessage": "Nome *"
@@ -1071,7 +1071,7 @@
     "defaultMessage": "Nenhuma encomenda encontrada."
   },
   "Pk14hW": {
-    "defaultMessage": "Lightning, on-chain Bitcoin, or card. Log in with your Nostr key. No KYC."
+    "defaultMessage": "Pagamento com Lightning Network, diretamente na blockchain do Bitcoin ou por cartão. Inicie sessão com a sua chave Nostr. Sem necessidade de verificação de identidade (KYC)."
   },
   "PlcGQq": {
     "defaultMessage": "Pay for this deployment before resizing it — an upgrade is charged pro-rata against the time left on the current period."
@@ -1281,7 +1281,7 @@
     "defaultMessage": "O que acontece aos meus eventos se eu deixar de pagar?"
   },
   "U0GEAC": {
-    "defaultMessage": "Stop uploading your images and video to someone else's server. Route96 is a Blossom and NIP-96 media server, deployed on LNVPS in minutes, with storage and TLS included."
+    "defaultMessage": "Pare de enviar suas imagens e vídeos para o servidor de outra pessoa. O Route96 é um servidor de mídia Blossom e NIP-96, implementado no LNVPS em poucos minutos, com armazenamento e TLS incluídos."
   },
   "U7fZs8": {
     "defaultMessage": "Quanto tempo demora?"
@@ -1290,7 +1290,7 @@
     "defaultMessage": "Guarde este cartão para pagamentos futuros."
   },
   "UANa+W": {
-    "defaultMessage": "Route96 is a high-performance Blossom / NIP-96 server. It is <a>open source</a>, and it is ours — we wrote it and we run it. You are not trusting a black box; you can read every line, and you can leave with your data whenever you want."
+    "defaultMessage": "O Route96 é um servidor Blossom/NIP-96 de alto desempenho. É um projeto de <a>código aberto</a> e pertence a nós — nós o desenvolvemos e somos responsáveis por sua operação. Não se trata de uma «caixa preta»; você pode ler cada linha do código e, quando quiser, poderá sair com seus dados."
   },
   "UPP+wZ": {
     "defaultMessage": "Em uso por: {count,plural,one{VM} other{Máquinas virtuais}}: {vms}"
@@ -1362,7 +1362,7 @@
     "defaultMessage": "{breakdown}. {storage} no total. Para um servidor de mídia pessoal, isso é suficiente; se precisar de mais, pode instalar o Route96 num VPS e expandir os recursos conforme necessário."
   },
   "W8nHSd": {
-    "defaultMessage": "FAQ"
+    "defaultMessage": "Perguntas frequentes"
   },
   "WEoZhh": {
     "defaultMessage": "Não foi possível encontrar uma subscrição para faturar esta atualização."
@@ -1497,7 +1497,7 @@
     "defaultMessage": "Guardar reaplica a configuração e reinicia a aplicação."
   },
   "aLe15X": {
-    "defaultMessage": "Pay how you like"
+    "defaultMessage": "Pague como preferir."
   },
   "aPcXT9": {
     "defaultMessage": "Os pagamentos são agrupados com outros participantes da rede e processados em uma única transação, assim que o seu saldo atingir o valor mínimo. A sua parte da taxa da rede é deduzida do seu saldo. Apenas endereços da rede principal."
@@ -1830,7 +1830,7 @@
     "defaultMessage": "SKILL.md"
   },
   "j52BNh": {
-    "defaultMessage": "Why self-host media"
+    "defaultMessage": "Por que hospedar seus próprios arquivos de mídia?"
   },
   "j7VE/p": {
     "defaultMessage": "Transação BTC padrão — creditada após confirmação"
@@ -1863,7 +1863,7 @@
     "defaultMessage": "Aponte um CNAME deste domínio para o nome de host da implementação assim que este for atribuído. Deixe vazio para remover."
   },
   "jhyC12": {
-    "defaultMessage": "What is included"
+    "defaultMessage": "O que está incluído?"
   },
   "jmVweB": {
     "defaultMessage": "A carregar as chaves SSH..."
@@ -1881,10 +1881,10 @@
     "defaultMessage": "IPv6"
   },
   "jzU8se": {
-    "defaultMessage": "Deploy Route96 — {price}/month"
+    "defaultMessage": "Implementar o Route96 — {price} por mês"
   },
   "k2S+Z0": {
-    "defaultMessage": "A protocol for storing and retrieving files addressed by their hash, designed to work with Nostr. NIP-96 is the older HTTP file-storage spec — Route96 speaks both."
+    "defaultMessage": "Um protocolo para armazenar e recuperar arquivos identificados pelo seu hash, projetado para funcionar com o Nostr. O NIP-96 é a especificação mais antiga para armazenamento de arquivos via HTTP – o Route96 suporta ambos."
   },
   "k9Pskm": {
     "defaultMessage": "Armazenamento SSD rápido"
@@ -1968,7 +1968,7 @@
     "defaultMessage": "Aplicações Gerenciadas: execute o software sem executar o servidor."
   },
   "mDRXDi": {
-    "defaultMessage": "Nostr keeps your identity portable. Media has been the part that is not — your images live on someone else's host, under someone else's terms, and disappear when they do. A Blossom server puts that back under your key."
+    "defaultMessage": "O Nostr mantém a sua identidade portátil. Os conteúdos multimédia são o aspeto que não o fazem: as suas imagens ficam armazenadas nos servidores de terceiros, sujeitas aos termos destes, e desaparecem quando estes decidem fazê-lo. Um servidor Blossom permite que volte a ter controlo sobre esses dados."
   },
   "mHEBOr": {
     "defaultMessage": "Você pode instalar o Bitcoin Core para mim?"
@@ -2121,7 +2121,7 @@
     "defaultMessage": "Serviço de hospedagem VPS em Quebec, Canadá, a partir de: {price} preço sem IVA. {minCpu}–{maxCpu} vCPU, até {maxDisk} {diskType}Pague em Bitcoin através da Lightning Network ou diretamente na blockchain."
   },
   "ps4K9r": {
-    "defaultMessage": "What is Blossom?"
+    "defaultMessage": "O que é o Blossom?"
   },
   "pus6h6": {
     "defaultMessage": "Pode sair a qualquer momento. O seu código deixa de gerar créditos e não poderá ser reutilizado."
@@ -2214,7 +2214,7 @@
     "defaultMessage": "As mensagens criptografadas estão disponíveis apenas para contas Nostr. A sua conta não tem uma chave Nostr para ler ou enviar mensagens NIP-17. Para obter ajuda, utilize o separador «Suporte»."
   },
   "sehISV": {
-    "defaultMessage": "Blossom Media Server Hosting from {price}/month"
+    "defaultMessage": "Serviço de alojamento do Blossom Media Server a partir de {price} por mês."
   },
   "sn+Rj5": {
     "defaultMessage": "Iniciar sessão com chave de acesso"
@@ -2388,7 +2388,7 @@
     "defaultMessage": "Atualização indisponível."
   },
   "xExBHw": {
-    "defaultMessage": "Your own hostname — <code>your-name.ie.apps.lnvps.cloud</code> — with automatic TLS"
+    "defaultMessage": "O seu próprio nome de domínio — <code>seu-nome.ie.apps.lnvps.cloud</code> — com TLS ativado automaticamente."
   },
   "xOnplm": {
     "defaultMessage": "A carregar os métodos de pagamento…"

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -711,7 +711,7 @@
     "defaultMessage": "Desligado/a"
   },
   "FZup6q": {
-    "defaultMessage": "Onde é que ele funciona/é exibido?"
+    "defaultMessage": "Onde é que ele funciona?"
   },
   "FazwRl": {
     "defaultMessage": "Tente novamente."

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -711,7 +711,7 @@
     "defaultMessage": "Отключено."
   },
   "FZup6q": {
-    "defaultMessage": "Где он работает/действует?"
+    "defaultMessage": "Где он работает?"
   },
   "FazwRl": {
     "defaultMessage": "Попробуйте ещё раз."

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -9,7 +9,7 @@
     "defaultMessage": "Исходящие (звонки/сообщения)"
   },
   "+Bj8tM": {
-    "defaultMessage": "Stopping retains your uploads; only deleting removes them"
+    "defaultMessage": "Если вы остановите процесс, загруженные файлы останутся. Только удаление приведет к их полному исчезновению."
   },
   "+EHk4e": {
     "defaultMessage": "Да. Это ваш компьютер, устанавливайте всё, что хотите."
@@ -171,7 +171,7 @@
     "defaultMessage": "Создать заказ"
   },
   "2lKQfH": {
-    "defaultMessage": "How much can I store?"
+    "defaultMessage": "Какой объём данных я могу хранить?"
   },
   "2mZOHz": {
     "defaultMessage": "Quote currency"
@@ -390,7 +390,7 @@
     "defaultMessage": "Оплатите сейчас."
   },
   "7v5vj0": {
-    "defaultMessage": "Host your own media server — {price} a month"
+    "defaultMessage": "Разместите собственный медиасервер — всего {price} в месяц."
   },
   "7wbySo": {
     "defaultMessage": "Отправьте нам сообщение, и наша команда свяжется с вами."
@@ -435,7 +435,7 @@
     "defaultMessage": "Сохранить способ выплаты."
   },
   "8dAKuZ": {
-    "defaultMessage": "Yes — CNAME, and the certificate is issued automatically once DNS resolves."
+    "defaultMessage": "Да, используется запись типа CNAME, и сертификат выдается автоматически после того, как разрешение DNS будет выполнено."
   },
   "8ecw1u": {
     "defaultMessage": "Ручки"
@@ -711,7 +711,7 @@
     "defaultMessage": "Отключено."
   },
   "FZup6q": {
-    "defaultMessage": "Where does it run?"
+    "defaultMessage": "Где он работает/действует?"
   },
   "FazwRl": {
     "defaultMessage": "Попробуйте ещё раз."
@@ -837,7 +837,7 @@
     "defaultMessage": "Готово."
   },
   "IbWc3k": {
-    "defaultMessage": "Dublin, Ireland."
+    "defaultMessage": "Дублин, Ирландия."
   },
   "Id24hd": {
     "defaultMessage": "Имя *"
@@ -1071,7 +1071,7 @@
     "defaultMessage": "Заказ не найден."
   },
   "Pk14hW": {
-    "defaultMessage": "Lightning, on-chain Bitcoin, or card. Log in with your Nostr key. No KYC."
+    "defaultMessage": "Оплата через Lightning Network, непосредственно в сети Bitcoin или банковской картой. Войдите в систему с помощью своего ключа Nostr. Проверка личности не требуется."
   },
   "PlcGQq": {
     "defaultMessage": "Pay for this deployment before resizing it — an upgrade is charged pro-rata against the time left on the current period."
@@ -1281,7 +1281,7 @@
     "defaultMessage": "Что произойдет с моими мероприятиями, если я прекращу оплату?"
   },
   "U0GEAC": {
-    "defaultMessage": "Stop uploading your images and video to someone else's server. Route96 is a Blossom and NIP-96 media server, deployed on LNVPS in minutes, with storage and TLS included."
+    "defaultMessage": "Прекратите загружать свои изображения и видео на серверы других пользователей. Route96 — это медиасервер Blossom и NIP-96, который можно развернуть на платформе LNVPS за считанные минуты, при этом в него уже включены хранилище данных и протокол TLS."
   },
   "U7fZs8": {
     "defaultMessage": "Сколько времени это займёт?"
@@ -1290,7 +1290,7 @@
     "defaultMessage": "Сохраните эту карту для будущих платежей."
   },
   "UANa+W": {
-    "defaultMessage": "Route96 is a high-performance Blossom / NIP-96 server. It is <a>open source</a>, and it is ours — we wrote it and we run it. You are not trusting a black box; you can read every line, and you can leave with your data whenever you want."
+    "defaultMessage": "Route96 — это высокопроизводительный сервер, совместимый с протоколами Blossom и NIP-96. Он имеет <a>открытый исходный код</a>, и он принадлежит нам — мы его разработали и поддерживаем. Вы не полагаетесь на «чёрный ящик»; вы можете просмотреть каждую строку кода и в любой момент получить доступ к своим данным."
   },
   "UPP+wZ": {
     "defaultMessage": "В настоящее время используется. {count,plural,one{ВМ} other{Виртуальные машины}}: {vms}"
@@ -1362,7 +1362,7 @@
     "defaultMessage": "{breakdown}. {storage} в целом. Для личного медиасервера этого вполне достаточно; если вам нужно больше, вы можете установить Route96 на виртуальный частный сервер (VPS) и масштабировать его по мере необходимости."
   },
   "W8nHSd": {
-    "defaultMessage": "FAQ"
+    "defaultMessage": "Часто задаваемые вопросы"
   },
   "WEoZhh": {
     "defaultMessage": "Не удалось найти подписку для оплаты этого обновления."
@@ -1497,7 +1497,7 @@
     "defaultMessage": "Сохранение заново применяет конфигурацию и перезапускает приложение."
   },
   "aLe15X": {
-    "defaultMessage": "Pay how you like"
+    "defaultMessage": "Оплачивайте удобным для вас способом."
   },
   "aPcXT9": {
     "defaultMessage": "Выплаты объединяются с другими реферальными ссылками в одну транзакцию, когда ваш баланс достигает минимального значения. Ваша доля сетевой комиссии вычитается из вашего баланса. Используются только адреса основной сети."
@@ -1830,7 +1830,7 @@
     "defaultMessage": "SKILL.md"
   },
   "j52BNh": {
-    "defaultMessage": "Why self-host media"
+    "defaultMessage": "Зачем размещать медиафайлы на собственном сервере?"
   },
   "j7VE/p": {
     "defaultMessage": "Обычная BTC-транзакция — зачисляется после подтверждения"
@@ -1863,7 +1863,7 @@
     "defaultMessage": "Направьте CNAME этого домена на имя хоста развёртывания, когда оно будет назначено. Оставьте пустым, чтобы удалить."
   },
   "jhyC12": {
-    "defaultMessage": "What is included"
+    "defaultMessage": "Что входит в комплект?"
   },
   "jmVweB": {
     "defaultMessage": "Загрузка SSH-ключей..."
@@ -1881,10 +1881,10 @@
     "defaultMessage": "IPv6"
   },
   "jzU8se": {
-    "defaultMessage": "Deploy Route96 — {price}/month"
+    "defaultMessage": "Разверните Route96 — {price} в месяц."
   },
   "k2S+Z0": {
-    "defaultMessage": "A protocol for storing and retrieving files addressed by their hash, designed to work with Nostr. NIP-96 is the older HTTP file-storage spec — Route96 speaks both."
+    "defaultMessage": "Протокол для хранения и извлечения файлов, адресуемых по их хеш-значению, разработанный для работы с Nostr. NIP-96 — это более старая спецификация для хранения файлов через HTTP; Route96 поддерживает оба протокола."
   },
   "k9Pskm": {
     "defaultMessage": "Быстрый твердотельный накопитель"
@@ -1968,7 +1968,7 @@
     "defaultMessage": "Управляемые приложения: запускайте программное обеспечение без запуска сервера."
   },
   "mDRXDi": {
-    "defaultMessage": "Nostr keeps your identity portable. Media has been the part that is not — your images live on someone else's host, under someone else's terms, and disappear when they do. A Blossom server puts that back under your key."
+    "defaultMessage": "Nostr обеспечивает переносимость вашей цифровой личности. В традиционных социальных сетях ваши данные хранятся на серверах других компаний, и вы не контролируете их условия хранения и использования. Кроме того, эти данные могут быть удалены в любой момент. Сервер Blossom возвращает контроль над вашими данными вам."
   },
   "mHEBOr": {
     "defaultMessage": "Вы можете установить Bitcoin Core для меня?"
@@ -2121,7 +2121,7 @@
     "defaultMessage": "Размещение VPS-серверов в Квебеке, Канада, от {price} без НДС. {minCpu}–{maxCpu} виртуальный процессор, до {maxDisk} {diskType}Оплачивайте в биткоинах через сеть Lightning или напрямую, используя основной блокчейн."
   },
   "ps4K9r": {
-    "defaultMessage": "What is Blossom?"
+    "defaultMessage": "Что такое Blossom?"
   },
   "pus6h6": {
     "defaultMessage": "Вы можете прекратить участие в любое время. После этого ваш код перестанет приносить доход и его нельзя будет использовать повторно."
@@ -2214,7 +2214,7 @@
     "defaultMessage": "Зашифрованные сообщения доступны только для аккаунтов Nostr. В вашем аккаунте отсутствует ключ Nostr, необходимый для чтения или отправки сообщений в формате NIP-17. Если вам нужна помощь, воспользуйтесь вкладкой «Поддержка»."
   },
   "sehISV": {
-    "defaultMessage": "Blossom Media Server Hosting from {price}/month"
+    "defaultMessage": "Размещение медиасервера Blossom Media — от {price} в месяц."
   },
   "sn+Rj5": {
     "defaultMessage": "Войти с ключом доступа"
@@ -2388,7 +2388,7 @@
     "defaultMessage": "Обновление недоступно."
   },
   "xExBHw": {
-    "defaultMessage": "Your own hostname — <code>your-name.ie.apps.lnvps.cloud</code> — with automatic TLS"
+    "defaultMessage": "Ваше собственное имя хоста — <code>your-name.ie.apps.lnvps.cloud</code> — с автоматической поддержкой TLS."
   },
   "xOnplm": {
     "defaultMessage": "Загрузка доступных способов оплаты…"

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -711,7 +711,7 @@
     "defaultMessage": "Bağlantı kesildi"
   },
   "FZup6q": {
-    "defaultMessage": "Nerede çalıştırılıyor/uygulanıyor?"
+    "defaultMessage": "Nerede çalıştırılıyor?"
   },
   "FazwRl": {
     "defaultMessage": "Tekrar deneyin."

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -9,7 +9,7 @@
     "defaultMessage": "Giden"
   },
   "+Bj8tM": {
-    "defaultMessage": "Stopping retains your uploads; only deleting removes them"
+    "defaultMessage": "Durdurma işlemi yüklemelerinizi saklar; yalnızca silme işlemi yüklemeleri tamamen kaldırır."
   },
   "+EHk4e": {
     "defaultMessage": "Evet. Bu sizin bilgisayarınız, istediğiniz yazılımı yükleyebilirsiniz."
@@ -171,7 +171,7 @@
     "defaultMessage": "Sipariş Oluştur"
   },
   "2lKQfH": {
-    "defaultMessage": "How much can I store?"
+    "defaultMessage": "Ne kadar veri depolayabilirim?"
   },
   "2mZOHz": {
     "defaultMessage": "Quote currency"
@@ -390,7 +390,7 @@
     "defaultMessage": "Şimdi öde"
   },
   "7v5vj0": {
-    "defaultMessage": "Host your own media server — {price} a month"
+    "defaultMessage": "Kendi medya sunucunuzu barındırın – ayda {price}."
   },
   "7wbySo": {
     "defaultMessage": "Bize doğrudan bir mesaj gönderin, ekip en kısa sürede size dönüş yapacaktır."
@@ -435,7 +435,7 @@
     "defaultMessage": "Ödeme Yöntemini Kaydet"
   },
   "8dAKuZ": {
-    "defaultMessage": "Yes — CNAME, and the certificate is issued automatically once DNS resolves."
+    "defaultMessage": "Evet, doğru – CNAME ve sertifika, DNS çözüldükten sonra otomatik olarak yayınlanır."
   },
   "8ecw1u": {
     "defaultMessage": "Kollar"
@@ -711,7 +711,7 @@
     "defaultMessage": "Bağlantı kesildi"
   },
   "FZup6q": {
-    "defaultMessage": "Where does it run?"
+    "defaultMessage": "Nerede çalıştırılıyor/uygulanıyor?"
   },
   "FazwRl": {
     "defaultMessage": "Tekrar deneyin."
@@ -837,7 +837,7 @@
     "defaultMessage": "Hazır."
   },
   "IbWc3k": {
-    "defaultMessage": "Dublin, Ireland."
+    "defaultMessage": "Dublin, İrlanda."
   },
   "Id24hd": {
     "defaultMessage": "Ad *"
@@ -1071,7 +1071,7 @@
     "defaultMessage": "Herhangi bir sipariş bulunamadı."
   },
   "Pk14hW": {
-    "defaultMessage": "Lightning, on-chain Bitcoin, or card. Log in with your Nostr key. No KYC."
+    "defaultMessage": "Şimşek Ağı, zincir üzerindeki Bitcoin veya kredi kartı ile ödeme yapabilirsiniz. Nostr anahtarınızla giriş yapın. Kimlik doğrulama gerekmiyor."
   },
   "PlcGQq": {
     "defaultMessage": "Pay for this deployment before resizing it — an upgrade is charged pro-rata against the time left on the current period."
@@ -1281,7 +1281,7 @@
     "defaultMessage": "Ödemeyi durdurursam, etkinliklerime ne olur?"
   },
   "U0GEAC": {
-    "defaultMessage": "Stop uploading your images and video to someone else's server. Route96 is a Blossom and NIP-96 media server, deployed on LNVPS in minutes, with storage and TLS included."
+    "defaultMessage": "Resimlerinizi ve videolarınızı başka birinin sunucusuna yüklemeyi bırakın. Route96, LNVPS üzerinde dakikalar içinde kurulabilen, depolama alanı ve TLS içeren Blossom ve NIP-96 medya sunucusudur."
   },
   "U7fZs8": {
     "defaultMessage": "Ne kadar sürüyor?"
@@ -1290,7 +1290,7 @@
     "defaultMessage": "Bu kartı gelecekteki ödemeler için saklayın."
   },
   "UANa+W": {
-    "defaultMessage": "Route96 is a high-performance Blossom / NIP-96 server. It is <a>open source</a>, and it is ours — we wrote it and we run it. You are not trusting a black box; you can read every line, and you can leave with your data whenever you want."
+    "defaultMessage": "Route96, yüksek performanslı bir Blossom/NIP-96 sunucusudur. <a>Açık kaynaklıdır</a> ve bize aittir; biz yazdık ve biz yönetiyoruz. Güvenmediğiniz bir kara kutu değil; her satırını okuyabilir ve istediğiniz zaman verilerinizle buradan ayrılabilirsiniz."
   },
   "UPP+wZ": {
     "defaultMessage": "Kullanımda olan {count,plural,one{Sanal Makine} other{Sanal makineler}}: {vms}"
@@ -1362,7 +1362,7 @@
     "defaultMessage": "{breakdown}. {storage} toplamda. Kişisel bir medya sunucusu için bu yeterli olacaktır; eğer daha fazlasına ihtiyacınız olursa, kendiniz kurduğunuz ve üzerine Route96 yüklediğiniz bir VPS ile ölçeklenebilirliği artırabilirsiniz."
   },
   "W8nHSd": {
-    "defaultMessage": "FAQ"
+    "defaultMessage": "Sıkça Sorulan Sorular"
   },
   "WEoZhh": {
     "defaultMessage": "Bu yükseltmenin faturalandırılacağı bir abonelik bulunamadı."
@@ -1497,7 +1497,7 @@
     "defaultMessage": "Kaydetmek yapılandırmayı yeniden uygular ve uygulamayı yeniden başlatır."
   },
   "aLe15X": {
-    "defaultMessage": "Pay how you like"
+    "defaultMessage": "İstediğiniz şekilde ödeme yapın."
   },
   "aPcXT9": {
     "defaultMessage": "Ödemeler, diğer zincir içi yönlendirenlerle birlikte birleştirilerek tek bir işlemde gerçekleştirilir; bu işlem, bakiyeniz minimum tutarı aştığında gerçekleşir. Ağ ücretinden düşülecek olan payınız, bakiyenizden kesilir. Yalnızca ana ağ adresleri geçerlidir."
@@ -1830,7 +1830,7 @@
     "defaultMessage": "BECERİLER.md"
   },
   "j52BNh": {
-    "defaultMessage": "Why self-host media"
+    "defaultMessage": "Neden medya içeriklerini kendi sunucunuzda barındırasınız?"
   },
   "j7VE/p": {
     "defaultMessage": "Standart BTC işlemi — onaydan sonra hesaba geçer"
@@ -1863,7 +1863,7 @@
     "defaultMessage": "Dağıtım ana bilgisayar adı atandığında bu alan adı için bir CNAME kaydını o adrese yönlendirin. Kaldırmak için boş bırakın."
   },
   "jhyC12": {
-    "defaultMessage": "What is included"
+    "defaultMessage": "Neler dahil?"
   },
   "jmVweB": {
     "defaultMessage": "SSH anahtarları yükleniyor..."
@@ -1881,10 +1881,10 @@
     "defaultMessage": "IPv6"
   },
   "jzU8se": {
-    "defaultMessage": "Deploy Route96 — {price}/month"
+    "defaultMessage": "Route96 oyununu kullanıma sunun — ayda {price}."
   },
   "k2S+Z0": {
-    "defaultMessage": "A protocol for storing and retrieving files addressed by their hash, designed to work with Nostr. NIP-96 is the older HTTP file-storage spec — Route96 speaks both."
+    "defaultMessage": "Nostr ile çalışacak şekilde tasarlanmış, dosyaları karma değerlerine göre saklayan ve erişimi sağlayan bir protokol. NIP-96, daha eski bir HTTP dosya depolama standardıdır; Route96 ise her ikisini de destekler."
   },
   "k9Pskm": {
     "defaultMessage": "Hızlı katı hal depolama (SSD)"
@@ -1968,7 +1968,7 @@
     "defaultMessage": "Yönetilen Uygulamalar: yazılımı sunucu çalıştırmadan çalıştırın."
   },
   "mDRXDi": {
-    "defaultMessage": "Nostr keeps your identity portable. Media has been the part that is not — your images live on someone else's host, under someone else's terms, and disappear when they do. A Blossom server puts that back under your key."
+    "defaultMessage": "Nostr, kimliğinizin taşınabilir kalmasını sağlar. Medya ise bu konuda farklı davranır; görselleriniz başka bir sunucuda, başkasının belirlediği koşullar altında saklanır ve o sunucu kapatıldığında kaybolur. Blossom sunucusu, bunları tekrar kontrolünüz altına almanızı sağlar."
   },
   "mHEBOr": {
     "defaultMessage": "Bitcoin Core'u benim için kurar mısınız?"
@@ -2121,7 +2121,7 @@
     "defaultMessage": "Kanada, Québec'te VPS sunucu hizmeti. {price} KDV hariç. {minCpu}–{maxCpu} sanal CPU, en fazla {maxDisk} {diskType}Bitcoin ile Lightning ağı veya doğrudan zincir üzerinden ödeme yapın."
   },
   "ps4K9r": {
-    "defaultMessage": "What is Blossom?"
+    "defaultMessage": "Blossom nedir?"
   },
   "pus6h6": {
     "defaultMessage": "İstediğiniz zaman çıkış yapabilirsiniz. Kodunuz artık geçerli olmayacak ve yeniden kullanılamayacaktır."
@@ -2214,7 +2214,7 @@
     "defaultMessage": "Şifreli mesajlaşma yalnızca Nostr hesapları için kullanılabilir. Hesabınızda NIP-17 mesajlarını okumak veya göndermek için gerekli Nostr anahtarı bulunmuyor. Yardım almak için lütfen Destek sekmesini kullanın."
   },
   "sehISV": {
-    "defaultMessage": "Blossom Media Server Hosting from {price}/month"
+    "defaultMessage": "Blossom Medya Sunucusu, aylık {price}'dan başlayan fiyatlarla hizmetinizde."
   },
   "sn+Rj5": {
     "defaultMessage": "Geçiş anahtarıyla giriş yap"
@@ -2388,7 +2388,7 @@
     "defaultMessage": "Yükseltme Mevcut Değil"
   },
   "xExBHw": {
-    "defaultMessage": "Your own hostname — <code>your-name.ie.apps.lnvps.cloud</code> — with automatic TLS"
+    "defaultMessage": "Kendi alan adınız — <code>your-name.ie.apps.lnvps.cloud</code> — otomatik TLS ile"
   },
   "xOnplm": {
     "defaultMessage": "Ödeme yöntemleri yükleniyor…"

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -9,7 +9,7 @@
     "defaultMessage": "外发；已发出。"
   },
   "+Bj8tM": {
-    "defaultMessage": "Stopping retains your uploads; only deleting removes them"
+    "defaultMessage": "停止操作会保留您已上传的内容；只有删除操作才会将其移除。"
   },
   "+EHk4e": {
     "defaultMessage": "是的。这是你的电脑，你可以安装你喜欢的任何软件。"
@@ -171,7 +171,7 @@
     "defaultMessage": "创建订单"
   },
   "2lKQfH": {
-    "defaultMessage": "How much can I store?"
+    "defaultMessage": "我可以存储多少数据？"
   },
   "2mZOHz": {
     "defaultMessage": "Quote currency"
@@ -390,7 +390,7 @@
     "defaultMessage": "立即付款。"
   },
   "7v5vj0": {
-    "defaultMessage": "Host your own media server — {price} a month"
+    "defaultMessage": "搭建您自己的媒体服务器——每月只需 {price}。"
   },
   "7wbySo": {
     "defaultMessage": "请直接给我们发送消息，我们的团队会尽快与您联系。"
@@ -435,7 +435,7 @@
     "defaultMessage": "保存提款方式。"
   },
   "8dAKuZ": {
-    "defaultMessage": "Yes — CNAME, and the certificate is issued automatically once DNS resolves."
+    "defaultMessage": "是的，使用 CNAME。一旦 DNS 解析成功，证书就会自动颁发。"
   },
   "8ecw1u": {
     "defaultMessage": "把手；处理；应对"
@@ -711,7 +711,7 @@
     "defaultMessage": "已断开连接。"
   },
   "FZup6q": {
-    "defaultMessage": "Where does it run?"
+    "defaultMessage": "它运行在哪里？"
   },
   "FazwRl": {
     "defaultMessage": "请重试。"
@@ -837,7 +837,7 @@
     "defaultMessage": "准备好了。"
   },
   "IbWc3k": {
-    "defaultMessage": "Dublin, Ireland."
+    "defaultMessage": "爱尔兰都柏林。"
   },
   "Id24hd": {
     "defaultMessage": "姓名 *"
@@ -1071,7 +1071,7 @@
     "defaultMessage": "未找到订单。"
   },
   "Pk14hW": {
-    "defaultMessage": "Lightning, on-chain Bitcoin, or card. Log in with your Nostr key. No KYC."
+    "defaultMessage": "可以使用闪电网络、链上比特币或银行卡进行支付。请使用您的 Nostr 私钥登录。无需进行身份验证（KYC）。"
   },
   "PlcGQq": {
     "defaultMessage": "Pay for this deployment before resizing it — an upgrade is charged pro-rata against the time left on the current period."
@@ -1281,7 +1281,7 @@
     "defaultMessage": "如果我停止付费，我的活动会怎样？"
   },
   "U0GEAC": {
-    "defaultMessage": "Stop uploading your images and video to someone else's server. Route96 is a Blossom and NIP-96 media server, deployed on LNVPS in minutes, with storage and TLS included."
+    "defaultMessage": "停止将您的图片和视频上传到其他人的服务器。Route96 是一款由 Blossom 和 NIP-96 开发的媒体服务器，可在 LNVPS 上几分钟内部署完成，并包含存储空间和 TLS 加密功能。"
   },
   "U7fZs8": {
     "defaultMessage": "需要多长时间？"
@@ -1290,7 +1290,7 @@
     "defaultMessage": "请保存此卡，以便今后使用。"
   },
   "UANa+W": {
-    "defaultMessage": "Route96 is a high-performance Blossom / NIP-96 server. It is <a>open source</a>, and it is ours — we wrote it and we run it. You are not trusting a black box; you can read every line, and you can leave with your data whenever you want."
+    "defaultMessage": "Route96 是一款高性能的 Blossom/NIP-96 服务器。它是<a>开源</a>的，并且由我们开发和维护。您无需依赖一个无法了解其内部机制的“黑盒”；您可以查看每一行代码，并且可以随时带着您的数据离开。"
   },
   "UPP+wZ": {
     "defaultMessage": "正在使用中。 {count,plural,one{虚拟机} other{虚拟机}}： {vms}"
@@ -1362,7 +1362,7 @@
     "defaultMessage": "{breakdown}…… {storage} 总的来说，对于个人媒体服务器而言，目前的配置已经足够；如果需要更高的性能，您可以自行安装 Route96 到虚拟专用服务器 (VPS) 上，以进一步提升。"
   },
   "W8nHSd": {
-    "defaultMessage": "FAQ"
+    "defaultMessage": "常见问题解答"
   },
   "WEoZhh": {
     "defaultMessage": "找不到可用于结算此次升级的订阅。"
@@ -1497,7 +1497,7 @@
     "defaultMessage": "保存后将重新应用配置并重启应用。"
   },
   "aLe15X": {
-    "defaultMessage": "Pay how you like"
+    "defaultMessage": "选择您喜欢的支付方式。"
   },
   "aPcXT9": {
     "defaultMessage": "当您的余额达到最低限额时，会将您的收益与其他链上推荐人的收益合并到一笔交易中。您的网络费用份额将从您的余额中扣除。仅适用于主网地址。"
@@ -1830,7 +1830,7 @@
     "defaultMessage": "技能.md"
   },
   "j52BNh": {
-    "defaultMessage": "Why self-host media"
+    "defaultMessage": "为什么要自己搭建媒体服务器？"
   },
   "j7VE/p": {
     "defaultMessage": "标准 BTC 交易 — 确认后到账"
@@ -1863,7 +1863,7 @@
     "defaultMessage": "在部署主机名分配后，将该域名的 CNAME 指向该主机名。留空可移除。"
   },
   "jhyC12": {
-    "defaultMessage": "What is included"
+    "defaultMessage": "包含哪些内容？"
   },
   "jmVweB": {
     "defaultMessage": "正在加载 SSH 密钥……"
@@ -1881,10 +1881,10 @@
     "defaultMessage": "IPv6"
   },
   "jzU8se": {
-    "defaultMessage": "Deploy Route96 — {price}/month"
+    "defaultMessage": "部署《Route96》——每月 {price}。"
   },
   "k2S+Z0": {
-    "defaultMessage": "A protocol for storing and retrieving files addressed by their hash, designed to work with Nostr. NIP-96 is the older HTTP file-storage spec — Route96 speaks both."
+    "defaultMessage": "这是一种用于存储和检索文件的协议，该协议通过文件哈希值来定位文件，并设计为与 Nostr 一起使用。NIP-96 是较早的 HTTP 文件存储规范——Route96 同时支持这两种规范。"
   },
   "k9Pskm": {
     "defaultMessage": "高速固态存储"
@@ -1968,7 +1968,7 @@
     "defaultMessage": "已管理的应用：运行软件，无需运行服务器。"
   },
   "mDRXDi": {
-    "defaultMessage": "Nostr keeps your identity portable. Media has been the part that is not — your images live on someone else's host, under someone else's terms, and disappear when they do. A Blossom server puts that back under your key."
+    "defaultMessage": "Nostr 使您的身份信息可以自由转移。目前，媒体内容往往存在一个问题，即无法完全自主掌控——您的图片存储在其他人的服务器上，受其规则约束，一旦对方停止服务，这些图片就会消失。Blossom 服务器可以将控制权重新交还给您。"
   },
   "mHEBOr": {
     "defaultMessage": "您能帮我安装比特币核心软件吗？"
@@ -2121,7 +2121,7 @@
     "defaultMessage": "位于加拿大魁北克的 VPS 服务器托管服务，提供商为： {price} 不含增值税。 {minCpu}——{maxCpu} 虚拟 CPU，最多可达 {maxDisk} {diskType}可以使用比特币通过闪电网络或主链进行支付。"
   },
   "ps4K9r": {
-    "defaultMessage": "What is Blossom?"
+    "defaultMessage": "什么是Blossom？"
   },
   "pus6h6": {
     "defaultMessage": "随时都可以停止。一旦停止，您的代码将不再产生收益，且无法再次使用。"
@@ -2214,7 +2214,7 @@
     "defaultMessage": "加密消息功能仅适用于 Nostr 账户。您的账户没有用于接收或发送 NIP-17 消息的 Nostr 密钥。如有需要，请使用“帮助”选项卡寻求支持。"
   },
   "sehISV": {
-    "defaultMessage": "Blossom Media Server Hosting from {price}/month"
+    "defaultMessage": "Blossom 媒体服务器，每月起价 {price}。"
   },
   "sn+Rj5": {
     "defaultMessage": "使用通行密钥登录"
@@ -2388,7 +2388,7 @@
     "defaultMessage": "无法升级。"
   },
   "xExBHw": {
-    "defaultMessage": "Your own hostname — <code>your-name.ie.apps.lnvps.cloud</code> — with automatic TLS"
+    "defaultMessage": "您自己的主机名——<code>your-name.ie.apps.lnvps.cloud</code>，并已启用自动 TLS。"
   },
   "xOnplm": {
     "defaultMessage": "正在加载支付方式……"


### PR DESCRIPTION
Closes #97.

20 of 35 message ids on this page were byte-identical to English in every one of the 10 non-English locale files — lede, FAQ, cards, meta description, all English regardless of visitor locale. Found while checking a stale worktree (`feat/blossom-landing-page`, PR #56, closed unmerged) for cleanup.

- 19 of the 20 reused PR #56's already-completed translations directly: verified byte-for-byte that #56's `en.json` matches current main's for each id before copying, so no translation is attached to text it wasn't written for. #56's own review already fixed the two defects it found (an `<a>` attribute the model added, breaking `formatjs compile-folder`, and "Route96" getting translated) — placeholder/tag equality checked programmatically across all 10 locales × 20 ids post-merge, all match.
- The 1 remaining id (`xUdVjn`, the bare word "Route96") wasn't in #56 at all — translated fresh via `ollama_intl`. First pass turned it into "the game Route96" in Arabic; regenerated once, second pass is in the right domain (no re-review possible past that, not fluent in Arabic).
- No source changes — locale JSON only.

Verified server-rendered, not just the JSON: `bun server/prod.ts` + `curl -H "Accept-Language: de/ru/ja/zh"` on `/blossom-server-hosting` — real translated `<title>`/`<h1>`/lede, "Route96" preserved as a brand name in all four.

`bun test` 44 pass, `tsc --noEmit` clean, build clean at 55f641a.