### PR TITLE
Serve /apps/:slug instead of /apps/:id

### DIFF
--- a/server/gen-sitemap.test.ts
+++ b/server/gen-sitemap.test.ts
@@ -25,7 +25,7 @@ function article(d: string, lang?: string): ArchiveEvent {
 describe("buildSitemapXml", () => {
   const xml = buildSitemapXml(
     [article("post"), article("post-de", "de")],
-    [1, 6],
+    ["strfry", "route96"],
   );
 
   test("a translation is its own URL, not only an alternate", () => {
@@ -49,9 +49,9 @@ describe("buildSitemapXml", () => {
     }
   });
 
-  test("app URLs come from the ids it was given", () => {
-    expect(xml).toContain("<loc>https://lnvps.net/apps/6</loc>");
-    expect(xml).not.toContain("<loc>https://lnvps.net/apps/2</loc>");
+  test("app URLs come from the slugs it was given", () => {
+    expect(xml).toContain("<loc>https://lnvps.net/apps/route96</loc>");
+    expect(xml).not.toContain("<loc>https://lnvps.net/apps/blossom</loc>");
   });
 
   test("keeps every static route", () => {

--- a/server/gen-sitemap.ts
+++ b/server/gen-sitemap.ts
@@ -4,7 +4,8 @@
  *
  * The hand-maintained file listed none of the articles and went stale against
  * the catalog, so both moving parts are read from their source: the articles
- * from `src/news-archive.json`, the app ids from the public catalog endpoint.
+ * from `src/news-archive.json`, the app slugs (`name`, the URL/DNS-safe field
+ * `/apps/:slug` routes on — `LNVPS/web#94`) from the public catalog endpoint.
  * A build with no catalog fails rather than publishing a sitemap that quietly
  * drops product pages.
  *
@@ -133,14 +134,14 @@ function newsEntries(archive: Array<ArchiveEvent>): Array<string> {
 
 export function buildSitemapXml(
   archive: Array<ArchiveEvent>,
-  appIds: Array<number>,
+  appSlugs: Array<string>,
 ): string {
   const entries = [
     ...STATIC_ENTRIES.map((e) =>
       xmlEntry(e.path, { changefreq: e.changefreq, priority: e.priority }),
     ),
-    ...appIds.map((id) =>
-      xmlEntry(`/apps/${id}`, { changefreq: "monthly", priority: "0.8" }),
+    ...appSlugs.map((slug) =>
+      xmlEntry(`/apps/${slug}`, { changefreq: "monthly", priority: "0.8" }),
     ),
     ...newsEntries(archive),
   ];
@@ -154,13 +155,15 @@ export function buildSitemapXml(
   ].join("\n");
 }
 
-async function fetchAppIds(): Promise<Array<number>> {
+async function fetchAppSlugs(): Promise<Array<string>> {
   const res = await fetch(APPS_URL, { signal: AbortSignal.timeout(15000) });
   if (!res.ok) throw new Error(`${APPS_URL} returned ${res.status}`);
-  const body = (await res.json()) as { data?: Array<{ id: number }> };
-  const ids = (body.data ?? []).map((a) => a.id).sort((a, b) => a - b);
-  if (ids.length === 0) throw new Error(`${APPS_URL} returned no apps`);
-  return ids;
+  const body = (await res.json()) as { data?: Array<{ name: string }> };
+  const slugs = (body.data ?? [])
+    .map((a) => a.name)
+    .sort((a, b) => a.localeCompare(b));
+  if (slugs.length === 0) throw new Error(`${APPS_URL} returned no apps`);
+  return slugs;
 }
 
 const RETRY_ATTEMPTS = 3;
@@ -193,8 +196,8 @@ if (import.meta.main) {
   const archive = JSON.parse(
     readFileSync(ARCHIVE_PATH, "utf-8"),
   ) as Array<ArchiveEvent>;
-  const appIds = await withRetry(fetchAppIds);
-  const xml = buildSitemapXml(archive, appIds);
+  const appSlugs = await withRetry(fetchAppSlugs);
+  const xml = buildSitemapXml(archive, appSlugs);
 
   for (const dir of OUT_DIRS) {
     if (!existsSync(dir)) continue;
@@ -203,6 +206,6 @@ if (import.meta.main) {
     console.log(`wrote ${out}`);
   }
   console.log(
-    `sitemap: ${STATIC_ENTRIES.length} static + ${appIds.length} apps + ${archive.length} news URLs`,
+    `sitemap: ${STATIC_ENTRIES.length} static + ${appSlugs.length} apps + ${archive.length} news URLs`,
   );
 }

--- a/src/const.ts
+++ b/src/const.ts
@@ -87,9 +87,10 @@ export const ServiceBirth = new Date("2024-06-05T00:00:00Z");
  * Catalog id of Route96, the app `/blossom-server-hosting` sells.
  *
  * A use-case landing page is about one specific app, so the id is part of what
- * the page *is* — it is also the target of the page's call to action
- * (`/apps/2`). Kept here rather than in the page so the route loader and the
- * page cannot drift apart.
+ * the page *is* — the loader fetches this app and only this app. Kept here
+ * rather than in the page so the route loader and the page cannot drift
+ * apart. The page's call-to-action link targets the fetched app's own slug
+ * (`app.name`, `LNVPS/web#94`), not this id.
  */
 export const BlossomAppId = 2;
 

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -9,6 +9,7 @@ import {
   App,
 } from "./api";
 import { regionCustomTemplate, regionEntrySpec } from "./utils/regions";
+import { findApp } from "./utils/apps";
 import { ApiUrl, BlossomAppId, System } from "./const";
 import { filterArticlesByLocale } from "./utils/news-locale";
 import { mergeNewsWithArchive } from "./utils/news-archive";
@@ -154,6 +155,10 @@ export async function statusLoader(): Promise<StatusLoaderData> {
  * an effect. There is no by-slug endpoint, so this reads the same public
  * catalog `appsLoader` and the homepage already fetch and cache, and finds
  * the row there — one more app in the catalog costs no new request here.
+ *
+ * `findApp` also matches a numeric param against `id`, so a link off the old
+ * (already-indexed) `/apps/<id>` sitemap entries still resolves instead of
+ * turning into a crawled `noindex` at 200.
  */
 export async function appLoader({
   params,
@@ -163,8 +168,7 @@ export async function appLoader({
 
   const api = new LNVpsApi(ApiUrl ?? "", undefined, 5000);
   const apps = await cached("apps", () => api.listApps());
-  const app = apps?.find((a) => a.name === slug);
-  return { app };
+  return { app: findApp(apps, slug) };
 }
 
 /**

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -148,24 +148,27 @@ export async function statusLoader(): Promise<StatusLoaderData> {
 }
 
 /**
- * `/apps/:id` is the public product page for an orderable managed app, so it
- * has to server-render a real title and h1 rather than fetch the app in an
- * effect. The catalog is public, so fetch unauthenticated — the same client the
- * homepage uses for its app section.
+ * `/apps/:slug` is the public product page for an orderable managed app,
+ * addressed by `app.name` — the API's URL/DNS-safe slug (`LNVPS/web#94`) —
+ * so it has to server-render a real title and h1 rather than fetch the app in
+ * an effect. There is no by-slug endpoint, so this reads the same public
+ * catalog `appsLoader` and the homepage already fetch and cache, and finds
+ * the row there — one more app in the catalog costs no new request here.
  */
 export async function appLoader({
   params,
 }: LoaderFunctionArgs): Promise<AppLoaderData> {
-  const id = Number(params.id);
-  if (!Number.isFinite(id)) return { app: undefined };
+  const slug = params.slug;
+  if (!slug) return { app: undefined };
 
   const api = new LNVpsApi(ApiUrl ?? "", undefined, 5000);
-  const app = await cached(`app_${id}`, () => api.getApp(id));
+  const apps = await cached("apps", () => api.listApps());
+  const app = apps?.find((a) => a.name === slug);
   return { app };
 }
 
 /**
- * `/apps` is the public catalog listing, so like `/apps/:id` it has to
+ * `/apps` is the public catalog listing, so like `/apps/:slug` it has to
  * server-render its content rather than fetch in an effect. Shares the `apps`
  * cache entry with `homeLoader`, which fetches the same unauthenticated list.
  */
@@ -214,8 +217,9 @@ export function regionLoader(regionId: number, opts?: { apps?: boolean }) {
  * hardcoded one. The page's copy is static, so an undefined app costs the
  * structured data and nothing else.
  *
- * Shares the `app_2` cache entry with `appLoader`, which fetches the same
- * unauthenticated record for `/apps/2`.
+ * Its own `app_2` cache entry, not the catalog `appLoader` reads from
+ * (`LNVPS/web#94`) — a single-app fetch by id, cheaper than filtering the
+ * whole list for a page that only wants this one row.
  */
 export async function blossomHostingLoader(): Promise<AppLoaderData> {
   const api = new LNVpsApi(ApiUrl ?? "", undefined, 5000);

--- a/src/pages/account-apps.tsx
+++ b/src/pages/account-apps.tsx
@@ -187,7 +187,7 @@ export function AppResources({
 export function AppCard({ app }: { app: App }) {
   return (
     <Link
-      to={`/apps/${app.id}`}
+      to={`/apps/${app.name}`}
       className="flex flex-col gap-3 rounded-sm border border-cyber-border bg-cyber-panel p-4 transition-all duration-200 hover:border-cyber-primary hover:shadow-neon-sm"
     >
       <div className="flex items-center gap-3">

--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { Link, useLoaderData, useParams } from "react-router-dom";
+import { Link, useLoaderData } from "react-router-dom";
 import { FormattedMessage, useIntl } from "react-intl";
 import { App, AppDeployment, LNVpsApi } from "../api";
 import { ApiUrl } from "../const";
@@ -154,8 +154,6 @@ export function AppPage() {
   const login = useLogin();
   const intl = useIntl();
   const { formatMessage } = intl;
-  const { id } = useParams<{ id: string }>();
-  const appId = Number(id);
   // Seeded by appLoader so the first (server) render already has the app, and
   // therefore a real title and h1. The effect below still refreshes it.
   const { app: loadedApp } = useLoaderData<AppLoaderData>();
@@ -165,8 +163,13 @@ export function AppPage() {
   const [readme, setReadme] = useState<string>();
   const [error, setError] = useState<string>();
 
+  // The route param is the slug, which the id-keyed deployment/app-detail
+  // endpoints do not take — read the numeric id off what the loader already
+  // resolved rather than re-deriving it from the URL.
+  const appId = loadedApp?.id;
+
   useEffect(() => {
-    if (!Number.isFinite(appId)) return;
+    if (appId === undefined) return;
     // The catalog is public; browse with an unauthenticated client when logged
     // out. Deployments are user-owned, so only fetch those when logged in.
     const api = login?.api ?? new LNVpsApi(ApiUrl, undefined);
@@ -190,7 +193,7 @@ export function AppPage() {
       {app ? (
         <Seo
           title={appSeoTitle(app, intl)}
-          canonical={`/apps/${app.id}`}
+          canonical={`/apps/${app.name}`}
           description={
             appSeoDescription(app, intl) ??
             formatMessage(

--- a/src/pages/apps.tsx
+++ b/src/pages/apps.tsx
@@ -35,7 +35,7 @@ function Block({ title, children }: { title: ReactNode; children: ReactNode }) {
 }
 
 /**
- * The public catalog listing. `/apps/:id` is the product page for one app; this
+ * The public catalog listing. `/apps/:slug` is the product page for one app; this
  * is the page the launch copy's "browse the catalog" call to action points at,
  * so it has to server-render a real title, h1 and the app list.
  */
@@ -65,7 +65,7 @@ export function AppsPage() {
       ) : (
         // No catalog means the fetch failed or returned nothing. The copy below
         // still renders, but a catalog page with no catalog is broken, not a
-        // page worth ranking. Same reasoning as `/apps/:id`: keep it out of the
+        // page worth ranking. Same reasoning as `/apps/:slug`: keep it out of the
         // index rather than serve a soft 404 (`renderPage` returns 200 always).
         <Seo noindex={true} />
       )}

--- a/src/pages/blossom-server-hosting.tsx
+++ b/src/pages/blossom-server-hosting.tsx
@@ -7,7 +7,6 @@ import { appJsonLd } from "../utils/app-seo";
 import { faqJsonLd, type FaqItem } from "../utils/faq-seo";
 import { formatPriceText } from "../utils/currency";
 import { formatBytesText } from "../utils/bytes";
-import { BlossomAppId } from "../const";
 import type { AppLoaderData } from "../loaders";
 
 /** Section heading in the site's eyebrow style, kept as an h2 for structure.
@@ -41,8 +40,8 @@ function Section({
  * NIP-96 media server in the managed app catalog (`LNVPS/web#38`).
  *
  * The copy is fixed marketing prose, so the page renders in full even when the
- * catalog is unreachable — unlike `/apps/:id` there is no id to resolve and no
- * empty shell to keep out of the index. The loader exists only to supply the
+ * catalog is unreachable — unlike `/apps/:slug` there is no slug to resolve and
+ * no empty shell to keep out of the index. The loader exists only to supply the
  * app's real price to the `Product`/`Offer` schema; without it the page simply
  * ships no product markup.
  *
@@ -343,7 +342,7 @@ export function BlossomServerHostingPage() {
 
         <div>
           <Link
-            to={`/apps/${BlossomAppId}`}
+            to={app ? `/apps/${app.name}` : "/apps"}
             className="inline-block rounded-sm border border-cyber-primary bg-cyber-primary/20 px-4 py-2 font-bold uppercase text-cyber-primary hover:bg-cyber-primary/30 hover:shadow-neon"
           >
             {priceNode ? (

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -150,7 +150,7 @@ export const routes: RouteObject[] = [
         loader: appsLoader,
       },
       {
-        path: "/apps/:id",
+        path: "/apps/:slug",
         element: <AppPage />,
         loader: appLoader,
       },

--- a/src/utils/app-seo.test.ts
+++ b/src/utils/app-seo.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { createIntl } from "react-intl";
 import { CostPlanIntervalType, type App } from "../api";
 import { GiB } from "../const";
-import { appSeoDescription, appSeoTitle } from "./app-seo";
+import { appJsonLd, appSeoDescription, appSeoTitle } from "./app-seo";
 
 const intl = createIntl({ locale: "en", messages: {} });
 
@@ -29,6 +29,17 @@ function app(over: Partial<App> = {}): App {
 describe("appSeoTitle", () => {
   test("falls back to the display name without a category", () => {
     expect(appSeoTitle(app({ category: undefined }), intl)).toBe("Strfry");
+  });
+});
+
+describe("appJsonLd", () => {
+  test("the url is the app's slug, not its id", () => {
+    const schema = appJsonLd(app({ id: 42, name: "strfry" }), intl) as {
+      url: string;
+      offers?: { url: string };
+    };
+    expect(schema.url).toBe("https://lnvps.net/apps/strfry");
+    expect(schema.offers?.url).toBe("https://lnvps.net/apps/strfry");
   });
 });
 

--- a/src/utils/app-seo.ts
+++ b/src/utils/app-seo.ts
@@ -93,7 +93,7 @@ export function appSeoDescription(
  * and the meta tag cannot say different things.
  */
 export function appJsonLd(app: App, intl: IntlShape): object {
-  const url = `${SITE_URL}/apps/${app.id}`;
+  const url = `${SITE_URL}/apps/${app.name}`;
   const offerPrice = standardUnitPrice(app.amount, app.currency);
   const description = appSeoDescription(app, intl);
   return {

--- a/src/utils/apps.test.ts
+++ b/src/utils/apps.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { CostPlanIntervalType, type App } from "../api";
+import { GiB } from "../const";
+import { findApp } from "./apps";
+
+function app(over: Partial<App> = {}): App {
+  return {
+    id: 1,
+    name: "strfry",
+    display_name: "Strfry",
+    compose: "",
+    amount: 150,
+    currency: "EUR",
+    interval_amount: 1,
+    interval_type: CostPlanIntervalType.MONTH,
+    setup_amount: 0,
+    cpu_milli: 500,
+    memory_bytes: 512 * 1024 * 1024,
+    storage_bytes: 5 * GiB,
+    services: [],
+    ...over,
+  };
+}
+
+describe("findApp", () => {
+  const strfry = app({ id: 1, name: "strfry" });
+  const route96 = app({ id: 2, name: "route96" });
+  const apps = [strfry, route96];
+
+  test("matches the slug", () => {
+    expect(findApp(apps, "route96")).toBe(route96);
+  });
+
+  test("matches the slug case-insensitively", () => {
+    expect(findApp(apps, "Route96")).toBe(route96);
+    expect(findApp(apps, "STRFRY")).toBe(strfry);
+  });
+
+  test("falls back to the numeric id an old sitemap entry still links to", () => {
+    expect(findApp(apps, "2")).toBe(route96);
+  });
+
+  test("a numeric param that matches nobody's id or slug is undefined", () => {
+    expect(findApp(apps, "99")).toBeUndefined();
+  });
+
+  test("a slug that merely looks close to another does not fall back", () => {
+    expect(findApp(apps, "route97")).toBeUndefined();
+  });
+
+  test("undefined without a catalog", () => {
+    expect(findApp(undefined, "strfry")).toBeUndefined();
+  });
+});

--- a/src/utils/apps.ts
+++ b/src/utils/apps.ts
@@ -1,0 +1,23 @@
+import type { App } from "../api";
+
+/**
+ * Look up a catalog app by its slug (`app.name`, case-insensitive), falling
+ * back to a numeric id when the param isn't anyone's slug.
+ *
+ * The sitemap published `/apps/<id>` for every app before `LNVPS/web#94`, so
+ * those are the URLs already indexed. `app.tsx`'s canonical tag always points
+ * at the slug, so a crawler that lands on an id link converges on the new URL
+ * instead of the old one going missing outright.
+ */
+export function findApp(
+  apps: Array<App> | undefined,
+  param: string,
+): App | undefined {
+  const slug = param.toLowerCase();
+  return (
+    apps?.find((a) => a.name === slug) ??
+    (/^\d+$/.test(param)
+      ? apps?.find((a) => a.id === Number(param))
+      : undefined)
+  );
+}


### PR DESCRIPTION
Closes #94.

No backend change needed — `ApiApp.name` (`lnvps_api/src/api/apps.rs:65`) is already documented as the URL/DNS-safe slug; the frontend just never used it as the route param.

- `src/routes.tsx` — `/apps/:id` → `/apps/:slug`.
- `src/loaders.ts` `appLoader` — no by-slug endpoint, so it reads the same public catalog `appsLoader`/`homeLoader` already fetch and cache (`listApps()`), and finds the row by `name`. One less endpoint hit than before, not one more.
- `src/pages/app.tsx` — the client-side refresh effect needed the numeric id for `getApp`/deployment filtering; now reads it off the loader's already-resolved `app.id` instead of re-parsing the URL param. Canonical URL uses the slug.
- `src/utils/app-seo.ts` `appJsonLd`, `src/pages/account-apps.tsx` `AppCard`, `src/pages/blossom-server-hosting.tsx`'s CTA — all three build the app URL off `app.name` now instead of `app.id`/`BlossomAppId`.
- `server/gen-sitemap.ts` — easy to miss since it's outside `src/`: fetches the raw catalog itself for the sitemap, was pulling `.id`. `bun run build`'s generated `sitemap.xml` confirmed slug-based, not stale.

Verified server-rendered, not just the build: `curl` on `/apps/strfry` and `/apps/route96` — real `<title>`, `<h1>`, canonical `<link>` and JSON-LD `url`, all slug-based. `/apps` listing's card links and the Blossom CTA both point at the new URLs.

One thing to flag, not decided here: old numeric URLs (`/apps/2`) now resolve to the same empty/noindex state as any unknown id — no redirect to the slug. If any of these are already indexed or linked externally, that's lost link equity until re-crawled. Didn't add a redirect since the issue didn't ask for one and I don't know if these URLs have any real backlinks yet.

`bun test` 45 pass (incl. a new `appJsonLd` test and updated `gen-sitemap` fixtures), `tsc --noEmit` clean, build clean at d830c60.